### PR TITLE
PHP7対応、及び既存不具合対応

### DIFF
--- a/app/controller/user/entries_controller.php
+++ b/app/controller/user/entries_controller.php
@@ -431,7 +431,7 @@ class EntriesController extends UserController
     }
     $entry['tags'] = array();
     $tags = $request->get('entry_tags');
-    if (count($tags)) {
+    if (is_countable($tags) && count($tags)) {
       foreach ($tags as $tag) {
         $entry['tags'][] = array(
           'id'      => 0,

--- a/app/core/common_functions.php
+++ b/app/core/common_functions.php
@@ -1,17 +1,5 @@
 <?php
 
-// magic_quotes対応
-if (get_magic_quotes_gpc()) {
-  function stripslashes_gpc(&$value)
-  {
-    $value = stripslashes($value);
-  }
-  array_walk_recursive($_GET, 'stripslashes_gpc');
-  array_walk_recursive($_POST, 'stripslashes_gpc');
-  array_walk_recursive($_COOKIE, 'stripslashes_gpc');
-  array_walk_recursive($_REQUEST, 'stripslashes_gpc');
-}
-
 // lcfirst関数補完
 if(function_exists('lcfirst') === false) {
   function lcfirst($str) {

--- a/app/core/common_functions.php
+++ b/app/core/common_functions.php
@@ -156,4 +156,14 @@ function setLanguage($lang=null, $file='messages'){
   textdomain($file);
 }
 
-
+/**
+ * 引数がcount関数で数えられる値かどうかを調べる
+ * ※PHP7.2よりcount関数の引数に数えられない値が指定された場合、E_WARNINGが発生
+ * ※PHP7.3より本関数は追加されている
+ */
+if (!function_exists('is_countable')) {
+    function is_countable ($var)
+    {
+        return (is_array($var) || $var instanceof Countable);
+    }
+}

--- a/app/core/debug.php
+++ b/app/core/debug.php
@@ -16,7 +16,10 @@ class Debug{
       // echoでデバッグ文を表示
       case 1:
         echo $msg;
-        if (count($params)) {
+        if (
+            is_countable($params)
+            && count($params)
+        ) {
           echo '<pre>';
           var_dump($params);
           echo '</pre>';
@@ -47,7 +50,11 @@ class Debug{
       // echoでデバッグ文を表示
       case 4:
         echo $msg . "\n";
-        if (count($params) && !empty($params)) {
+        if (
+            is_countable($params)
+            && count($params)
+            && !empty($params)
+        ) {
           var_dump($params);
           echo "\n";
         }

--- a/app/core/my_sqli_wrap.php
+++ b/app/core/my_sqli_wrap.php
@@ -169,7 +169,7 @@ class MySqliWrap implements DBInterface{
         default:
           $type = "string";
         case 'boolean': case 'integer': case 'double': case 'string':
-          $types .= $type{0};
+          $types .= $type[0];
       }
     }
     return $types;

--- a/app/lib/CaptchaImage.php
+++ b/app/lib/CaptchaImage.php
@@ -76,13 +76,13 @@ class CaptchaImage
       if ($this->hirakana_mode) {
         //描画文字
         if(mt_rand(0,1)) {
-          $char = $hirakana[ $tmp_str{$i} ];//ひらかな
+          $char = $hirakana[ $tmp_str[$i] ];//ひらかな
         }  else {
-          $char = $katakana[ $tmp_str{$i} ];//カタカナ
+          $char = $katakana[ $tmp_str[$i] ];//カタカナ
         }
       }  else {
         //日本語は使わず数字だけの場合
-        $char = $tmp_str{$i};
+        $char = $tmp_str[$i];
       }
 
       $angle = mt_rand( -10, 10 );// 角度

--- a/app/model/blog_plugins_model.php
+++ b/app/model/blog_plugins_model.php
@@ -253,9 +253,14 @@ class BlogPluginsModel extends Model
   */
   public function insert($values, $options=array())
   {
+    $default_values = [
+        'list' => '',
+        'attribute' => '',
+    ];
+    $values += $default_values;
+
     $values['updated_at'] = $values['created_at'] = date('Y-m-d H:i:s');
     $values['plugin_order'] = $this->getNextPluginOrder($values['blog_id'], $values['device_type'], $values['category']);
-    $values['list'] = '';
     $id = parent::insert($values, $options);
     if ($id) {
       // プラグインのPHPファイル作成

--- a/app/model/blog_plugins_model.php
+++ b/app/model/blog_plugins_model.php
@@ -255,6 +255,7 @@ class BlogPluginsModel extends Model
   {
     $values['updated_at'] = $values['created_at'] = date('Y-m-d H:i:s');
     $values['plugin_order'] = $this->getNextPluginOrder($values['blog_id'], $values['device_type'], $values['category']);
+    $values['list'] = '';
     $id = parent::insert($values, $options);
     if ($id) {
       // プラグインのPHPファイル作成

--- a/app/model/blog_templates_model.php
+++ b/app/model/blog_templates_model.php
@@ -177,6 +177,10 @@ class BlogTemplatesModel extends Model
   */
   public function insert($values, $options=array())
   {
+    $default_values = [
+      'template_id' => 0,
+    ];
+    $values += $default_values;
     $values['updated_at'] = $values['created_at'] = date('Y-m-d H:i:s');
     $id = parent::insert($values, $options);
 

--- a/app/model/plugins_model.php
+++ b/app/model/plugins_model.php
@@ -108,7 +108,7 @@ class PluginsModel extends Model
     foreach ($plugins as $plugin) {
       $plugin['list'] = '';
       $plugin['attribute'] = '{}';
-      $plugin['created_at'] = $plugins['updated_at'] = date('Y-m-d H:i:s');
+      $plugin['created_at'] = $plugin['updated_at'] = date('Y-m-d H:i:s');
       $this->insert($plugin);
     }
   }

--- a/app/view/admin/files/ajax_index.html
+++ b/app/view/admin/files/ajax_index.html
@@ -99,7 +99,7 @@ $(function(){
     $.ajax({
       url: '<?php echo Html::url(array('controller'=>'Files', 'action'=>'ajax_delete')); ?>',
       type: 'POST',
-      data: {id: ids, sig: <?php echo Session::get('sig'); ?>},
+      data: {id: ids, sig: '<?php echo Session::get('sig'); ?>'},
       dataType: 'json',
       success: function(json){
         // 削除完了後検索処理を実行

--- a/public/js/elrte/src/post.php
+++ b/public/js/elrte/src/post.php
@@ -1,5 +1,4 @@
 <?php
-set_magic_quotes_runtime(0);
 
 if (isset($_GET['debug'])) {
 	echo '<pre>';


### PR DESCRIPTION
**＜PHP7対応の修正＞**
- PHP7環境で発生する全てのエラー(Warning、Deprecated等)を解消し、動作するように改修いたしました。
- 本改修によりPHP5系では動作は保証されません

---
**＜修正した既存不具合＞**
- 初回インストール：公式プラグインの更新日時が「0000-00-00 00:00:00」で登録されている不具合修正
【原因】
DB登録に使用する更新日時の変数名が間違っていたので、カラム指定がされていなかったため。
※MySQL5.6以降の環境ではエラーとなりインサート自体できません。

- ファイルアップロード画面：ファイル一括削除ができないことがある
事象1：「選択したものを全て削除する」ボタンが押下可能な状態にならない
原因1：PHP出力値によりJavaScriptが構文エラーとなるため
事象2：削除時にエラーとなる
原因2：PHP出力値によりJavaScriptで未定義の変数のエラーになるため

---
**＜改修後の動作確認環境＞**
【PHP7.0環境】
CentOS 7.8 (2003)
Apache/2.4.6
MariaDB 10.4.13
PHP 7.0.33

【PHP7.4環境】
CentOS 7.8 (2003)
Apache/2.4.6
MariaDB 10.4.13
PHP 7.4.7