### PR TITLE
Update Docker configuration. Fix i18n and php log output, add SSL support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,3 +30,4 @@ services:
       - ./docker/docker.config.php:/var/www/html/config.php
     ports:
       - 8080:80
+      - 8480:443

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -3,10 +3,12 @@ FROM php:7.4-apache
 RUN set -eux \
  && apt-get update -y \
  && apt-get upgrade -y \
- && apt-get install -y git autoconf g++ libtool make libzip-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev \
+ && apt-get install -y git autoconf g++ libtool make libzip-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev libicu-dev locales \
+ && sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
+ && locale-gen \
  && docker-php-ext-configure gd --with-jpeg=/usr \
  && docker-php-ext-configure opcache --enable-opcache \
- && docker-php-ext-install opcache bcmath pdo_mysql gd exif zip gettext\
+ && docker-php-ext-install opcache bcmath pdo_mysql gd exif zip gettext intl \
  && rm -rf /tmp/*
 
 RUN a2enmod rewrite

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -3,7 +3,7 @@ FROM php:7.4-apache
 RUN set -eux \
  && apt-get update -y \
  && apt-get upgrade -y \
- && apt-get install -y git autoconf g++ libtool make libzip-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev libicu-dev locales \
+ && apt-get install -y git autoconf g++ libtool make libzip-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev libicu-dev locales ssl-cert \
  && sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
  && locale-gen \
  && docker-php-ext-configure gd --with-jpeg=/usr \
@@ -11,5 +11,8 @@ RUN set -eux \
  && docker-php-ext-install opcache bcmath pdo_mysql gd exif zip gettext intl \
  && rm -rf /tmp/*
 
-RUN a2enmod rewrite
+RUN a2enmod rewrite \
+ && a2enmod ssl \
+ && a2ensite default-ssl
+
 

--- a/docker/docker.config.php
+++ b/docker/docker.config.php
@@ -3,6 +3,12 @@
 // (この設定ファイルはDockerによる開発用のファイルです。 *公開サイトには使わないでください* ）
 
 error_reporting(-1);
+ini_set('error_log', 'php://stderr');
+ini_set('log_errors', '1');
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
+ini_set('html_errors', '1');
+ini_set('ignore_repeated_errors', '0');
 
 // 直接呼び出された場合は終了
 if (count(get_included_files())==1) {
@@ -21,5 +27,5 @@ define('DOMAIN',        'localhost');           // ドメイン名
 define('PASSWORD_SALT', '7efe3a5b4d111b9e2148e24993c1cfdb'); // 適当な英数字を入力してください
 
 // 設定クラス読み込み
-define('WWW_DIR', dirname(__FILE__) . '/');
+define('WWW_DIR', '/var/www/html/');
 require(dirname(__FILE__) . '/../app/core/bootstrap.php');


### PR DESCRIPTION
- 環境に`ja_JP.UTF-8` localeを追加し、gettext(多国語対応の日本語表示)が正しく動作していなかったのを修正
- ログがdocker logsに出力されていなかったのを修正
- 初期状態でインストール時に「アップロードディレクトリへの書き込み権限」がNGだったのを修正
- `https://127.0.0.1:8480/` で、SSL接続できるように ( #17 の布石）

> 最近のChrome（すくなくとも、v84.0.4147.89）は自己署名証明書をブロックし、「信頼する」ボタンが消えましたが、 `NET::ERR_CERT_INVALID` エラー画面で `thisisunsafe` とタイプする(特に入力欄を選択したりとかは不要)ことで回避ができるテクがあります。