### PR TITLE
Fix Docker env: missing imagettfbbox(), add free-type support to gd.

### DIFF
--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -3,10 +3,10 @@ FROM php:7.4-apache
 RUN set -eux \
  && apt-get update -y \
  && apt-get upgrade -y \
- && apt-get install -y git autoconf g++ libtool make libzip-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev libicu-dev locales ssl-cert \
+ && apt-get install -y git autoconf g++ libtool make libzip-dev libpng-dev libjpeg62-turbo-dev libfreetype6-dev libicu-dev locales ssl-cert libfreetype6-dev \
  && sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
  && locale-gen \
- && docker-php-ext-configure gd --with-jpeg=/usr \
+ && docker-php-ext-configure gd --with-jpeg=/usr --with-freetype=/usr \
  && docker-php-ext-configure opcache --enable-opcache \
  && docker-php-ext-install opcache bcmath pdo_mysql gd exif zip gettext intl \
  && rm -rf /tmp/*


### PR DESCRIPTION
Docker環境において、Freetype指定がぬけていたために `imagettfbbox()`が不足しており、日本語のCaptchaが正しく動作していなかったのを修正しました。