### PR TITLE
Session cookieのセキュリティ強化

### DIFF
--- a/app/config/env.php
+++ b/app/config/env.php
@@ -68,14 +68,14 @@ $config['HTTP_PORT_STR'] = (HTTP_PORT === "80") ? '' : ":" . HTTP_PORT; // http�
 $config['HTTPS_PORT_STR'] = (HTTP_PORT === "443") ? '' : ":" . HTTPS_PORT; // https時、443は省略できる
 
 // Sessionのデフォルト有効ドメイン
-$config['SESSION_DEFAULT_DOMAIN'] = $config['DOMAIN'];
+$config['SESSION_DEFAULT_DOMAIN'] = ""; // 省略時、アクセスドメインとなります
 
 // SESSIONのID名
 $config['SESSION_NAME'] = 'dojima';
 
 // Cookieのデフォルト有効ドメイン
-$config['COOKIE_DEFAULT_DOMAIN'] = $config['DOMAIN'];
-$config['COOKIE_EXPIRE'] = 180;   // 有効期限 180日
+$config['COOKIE_DEFAULT_DOMAIN'] = ""; // JS用Cookie名 省略時、アクセスドメインとなります
+$config['COOKIE_EXPIRE'] = 180; // 有効期限 180日
 
 // URLの形式を書き換えるフラグ
 $config['URL_REWRITE'] = false;

--- a/app/core/cookie.php
+++ b/app/core/cookie.php
@@ -16,22 +16,84 @@ class Cookie{
   }
 
   /**
-  * クッキーから情報を取得し破棄する
-  */
-  public static function remove($key, $default=null){
+   * クッキーから情報を取得し破棄する
+   * @param string $key
+   * @param string|null $default
+   * @return string|null
+   */
+  public static function remove(string $key, string $default = null)
+  {
     $value = self::get($key, $default);
-    self::set($key, null);
+    self::set($key, null, time() - 3600);
     return $value;
   }
 
   /**
-  * クッキーに情報を保存する
-  */
-  public static function set($key, $value, $timeout=0, $path='/', $domain=null){
-    if ($domain===null) {
-      $domain = Config::get('COOKIE_DEFAULT_DOMAIN');
+   * クッキーに情報を保存する
+   * @param string $key
+   * @param string $value
+   * @param int $expires
+   * @param string $path
+   * @param string $domain
+   * @param bool $secure
+   * @param bool $httponly
+   * @param string $samesite
+   *
+   * NOTE: httpアクセスも許可する仕様がなければ、secureを$_SERVER['https']をみてtrueにすべきではないか
+   */
+  public static function set(string $key,
+                             string $value,
+                             int $expires = 0,
+                             string $path = "",
+                             string $domain = "",
+                             bool $secure = false,
+                             bool $httponly = true,
+                             string $samesite = "Lax")
+  {
+    $params = [];
+    $params['expires'] = $expires;
+    $params['path'] = $path;
+    $params['domain'] = $domain;
+
+    // SSLターミネーションがある環境においては検討が必要
+    if ($secure === true && (isset($_SERVER['https']) && $_SERVER['https'] === "on")) {
+      $params['secure'] = true;
     }
-    setcookie($key, $value, $timeout, $path, $domain);
+
+    // setcookieではデフォルトfalseだが、セキュリティのためにtrueをデフォルト化
+    if ($httponly === true) {
+      $params['httponly'] = $httponly;
+    }
+
+    // samesiteはhttp対応のために今後通常となるLaxをデフォルト
+    if (false === in_array($samesite, static::cookieSamesiteAllowedList)) {
+      throw new InvalidArgumentException("invalid samesite parameter");
+    }
+    $params['samesite'] = $samesite;
+
+    // domainは特別にコンフィグで設定されないかぎり空で、アクセスドメインに発行
+    if (strlen($domain) > 0) {
+      $params['domain'] = $domain;
+    } else if (strlen(Config::get('COOKIE_DEFAULT_DOMAIN')) > 0) {
+      $params['domain'] = $domain = Config::get('COOKIE_DEFAULT_DOMAIN');
+    }
+
+    // 不可能な組み合わせを拒否
+    if (
+      (isset($params['samesite']) && $params['samesite'] === "None") &&
+      (isset($params['secure']) && $params['secure'] !== true) &&
+      (isset($_SERVER['https']) && $_SERVER['https'] !== "on")
+    ) {
+      throw new InvalidArgumentException("samesite=None needs https.");
+    }
+
+    setcookie(
+      $key,
+      $value,
+      $params
+    );
   }
 
+  // Cookieのsamesiteパラメタに指定可能な値のバリエーション
+  const cookieSamesiteAllowedList = ['None', 'Lax', 'Strict'];
 }

--- a/app/core/cookie.php
+++ b/app/core/cookie.php
@@ -1,14 +1,16 @@
 <?php
 /**
-* Cookieクラス
-*/
+ * Cookieクラス
+ */
 
-class Cookie{
+class Cookie
+{
 
   /**
-  * クッキーから情報を取得する
-  */
-  public static function get($key, $default=null){
+   * クッキーから情報を取得する
+   */
+  public static function get($key, $default = null)
+  {
     if (isset($_COOKIE[$key])) {
       return $_COOKIE[$key];
     }
@@ -56,7 +58,10 @@ class Cookie{
     $params['domain'] = $domain;
 
     // SSLターミネーションがある環境においては検討が必要
-    if ($secure === true && (isset($_SERVER['https']) && $_SERVER['https'] === "on")) {
+    if ($secure === true) {
+      if (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] !== "on") {
+        throw new InvalidArgumentException("secure=true needs https.");
+      }
       $params['secure'] = true;
     }
 
@@ -80,9 +85,11 @@ class Cookie{
 
     // 不可能な組み合わせを拒否
     if (
-      (isset($params['samesite']) && $params['samesite'] === "None") &&
-      (isset($params['secure']) && $params['secure'] !== true) &&
-      (isset($_SERVER['https']) && $_SERVER['https'] !== "on")
+      $samesite === "None" &&
+      (
+        $secure !== true ||
+        (!isset($_SERVER['HTTPS']) || $_SERVER['HTTPS'] !== "on")
+      )
     ) {
       throw new InvalidArgumentException("samesite=None needs https.");
     }

--- a/app/core/session.php
+++ b/app/core/session.php
@@ -18,7 +18,20 @@ class Session
     if (headers_sent()) {
       return;
     }
-    session_set_cookie_params(0 , '/', Config::get('SESSION_DEFAULT_DOMAIN'));
+
+    $session_cookie_options = [
+      "lifetime" => 0,
+      "path" => "/",
+      "httponly" => true,
+      "samesite" => "Lax" // NOTE: 要件としてhttpサポートがあるため、None属性は指定ができない
+      // NOTE: 要件としてhttpサポートがあるため secure属性は指定ができない
+    ];
+
+    if (strlen(Config::get('SESSION_DEFAULT_DOMAIN')) > 0) {
+      $session_cookie_options['domain'] = Config::get('SESSION_DEFAULT_DOMAIN');
+    }
+
+    session_set_cookie_params($session_cookie_options);
     session_name(Config::get('SESSION_NAME'));
     session_start();
     self::$isStart = true;
@@ -80,7 +93,7 @@ class Session
   {
     $_SESSION = array();
     if (isset($_COOKIE[Config::get('SESSION_NAME')])) {
-      Cookie::set(Config::get('SESSION_NAME'), '', time() - 86400);
+      Cookie::remove(Config::get('SESSION_NAME'), '');
     }
     session_destroy();
   }

--- a/tests/App/Core/Cookie/SetTest.php
+++ b/tests/App/Core/Cookie/SetTest.php
@@ -1,0 +1,104 @@
+<?php
+declare(strict_types=1);
+
+namespace Fc2blog\Tests\App\Core\Cookie;
+
+use Cookie;
+use Fc2blog\Tests\LoaderHelper;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use TypeError;
+
+class SetTest extends TestCase
+{
+  public function setUp(): void
+  {
+    LoaderHelper::requireBootStrap();
+    parent::setUp();
+  }
+
+  public function testSetString(): void
+  {
+    // Cookieの正しいテストはUnitTestでは困難です
+    // echo '<?php setcookie("1","b");' | php-cgi
+    // 等でテストができますが、php-cgiがない環境でテストが実行できません。
+    @Cookie::set("k", "v");
+    $this->assertTrue(true);
+  }
+
+  public function testSetInvalidType(): void
+  {
+    try {
+      /** @noinspection PhpStrictTypeCheckingInspection */
+      Cookie::set(true, "v");
+      $this->fail();
+    } catch (TypeError $e) {
+      $this->assertInstanceOf(TypeError::class, $e);
+    }
+
+    try {
+      /** @noinspection PhpStrictTypeCheckingInspection */
+      Cookie::set(1, "v");
+      $this->fail();
+    } catch (TypeError $e) {
+      $this->assertInstanceOf(TypeError::class, $e);
+    }
+
+    try {
+      /** @noinspection PhpStrictTypeCheckingInspection */
+      Cookie::set("k", true);
+      $this->fail();
+    } catch (TypeError $e) {
+      $this->assertInstanceOf(TypeError::class, $e);
+    }
+
+    try {
+      /** @noinspection PhpStrictTypeCheckingInspection */
+      Cookie::set("k", 1);
+      $this->fail();
+    } catch (TypeError $e) {
+      $this->assertInstanceOf(TypeError::class, $e);
+    }
+  }
+
+  public function testDenyInvalidSamesite(): void
+  {
+    try {
+      @Cookie::set("k", "v", time(), "", "", false, false, "Lax");
+      $this->assertTrue(true);
+    } catch (InvalidArgumentException $e) {
+      $this->fail($e->getMessage());
+    }
+    try {
+      @Cookie::set("k", "v", time(), "", "", false, false, "Strict");
+      $this->assertTrue(true);
+    } catch (InvalidArgumentException $e) {
+      $this->fail($e->getMessage());
+    }
+    try {
+      $_SERVER['HTTPS'] = "on";
+      @Cookie::set("k", "v", time(), "", "", true, false, "None");
+      $this->assertTrue(true);
+    } catch (InvalidArgumentException $e) {
+      $this->fail($e->getMessage());
+    } finally {
+      unset($_SERVER['HTTPS']);
+    }
+    try {
+      @Cookie::set("k", "v", time(), "", "", false, false, "Wrong");
+      $this->fail();
+    } catch (InvalidArgumentException $e) {
+      $this->assertTrue(true);
+    }
+  }
+
+  public function testSamesiteNoneAndNotSecure(): void
+  {
+    try {
+      @Cookie::set("k", "v", time(), "", "", false, false, "None");
+      $this->fail();
+    } catch (InvalidArgumentException $e) {
+      $this->assertTrue(true);
+    }
+  }
+}

--- a/tests/App/Core/Cookie/SetTest.php
+++ b/tests/App/Core/Cookie/SetTest.php
@@ -95,10 +95,30 @@ class SetTest extends TestCase
   public function testSamesiteNoneAndNotSecure(): void
   {
     try {
+      unset($_SERVER['HTTPS']);
+      @Cookie::set("k", "v", time(), "", "", true, false, "None");
+      $this->fail();
+    } catch (InvalidArgumentException $e) {
+      $this->assertTrue(true);
+    }
+
+    try {
+      $_SERVER['HTTPS'] = "on";
       @Cookie::set("k", "v", time(), "", "", false, false, "None");
       $this->fail();
     } catch (InvalidArgumentException $e) {
       $this->assertTrue(true);
+    } finally {
+      unset($_SERVER['HTTPS']);
+    }
+
+    try {
+      $_SERVER['HTTPS'] = "on";
+      @Cookie::set("k", "v", time(), "", "", true, false, "None");
+    } catch (InvalidArgumentException $e) {
+      $this->fail($e->getMessage());
+    } finally {
+      unset($_SERVER['HTTPS']);
     }
   }
 }


### PR DESCRIPTION
- Improve cookie security
- enable "httponly" on session cookie. 
- remove "SESSION_DEFAULT_DOMAIN" from default config.
- add samesite support.

## 例

![貼り付けた画像_2020_08_01_22_40](https://user-images.githubusercontent.com/870716/89103671-6b3e3d00-d44e-11ea-9082-2dd3b3e1a1c2.png)

## samesite指定について

現状httpサイトが必須要件（http/https切り替え機能）といただいたので、Noneの指定ができない。
当方が把握している範囲では、Strict指定でよいと思えるが（外部サイト認証もないので）、当座はモダンブラウザの基本となるLaxでよいかと思われる。
（古いブラウザでは無視される）。

補記：
上記「無視される」は、「Noneが必要なユースケース」を当方で特定できていないためです。
本当の意味で「None」の挙動が必要であれば、機種依存の対応が必要となります。
https://www.chromium.org/updates/same-site/incompatible-clients
（が、いずれにせよ最大シェアブラウザにおいてhttps必須になるのでどうなのでしょうか？）

## secure指定について

前述の理由で、現状はオフ指定がデフォルト。

## httponlyについて

JSなどで利用されているわけではなく、問題なく適用できるようにみえたため、有効化。

## ドメイン指定について

OSS版においては特にクロスサイト設定ができる必要がみえないので、「空」（アクセスドメイン）をデフォルトに。
コンフィグで指定することで ルートドメインのCookieを発行することは可能。

## セッションではない、ブラウザJSのCookieについて

ドメインについては同様にデフォルト空としたが、それ以外は手をつけていない。

- Cookie操作に使われているライブラリが古い [（このあたり）](https://github.com/fc2blog/blog/blob/ca17e5b6a6fd471aca6fc4e3ffc435cede27e59c/app/config/fc2_default_template.php#L39)
- UIの設定保存のためでセッションとしてつかわれていない模様

ライブラリの更新からすべきとおもわれますが、かなり書き換えの範囲がありそうです。ご検討ください。

現行 jQuery Cookie Plugin v1.4.0（https://github.com/carhartl/jquery-cookie ）はふるく、samesiteなど対応無し。
上記プラグインのリポジトリより、後継として指定されている js-cookie v2.2.1（https://github.com/js-cookie/js-cookie ） はsamesiteなど対応している模様（jQuery Pluginではなくなっている）。

（作業時間 4h


