### PR TITLE
ユーザー側画面 e2eテスト追加

### DIFF
--- a/app/controller/user/common_controller.php
+++ b/app/controller/user/common_controller.php
@@ -55,7 +55,12 @@ class CommonController extends UserController
     require_once(Config::get('LIB_DIR') . 'CaptchaImage.php');
     $size_x = 200;
     $size_y = 40;
-    $key = random_int(1000, 9999);
+    // 自動テスト用に"DEBUG_FORCE_CAPTCHA_KEY"環境変数で、Captchaキーの固定機能
+    if (strlen((string)getenv("DEBUG_FORCE_CAPTCHA_KEY")) === 4) {
+      $key = (int)getenv("DEBUG_FORCE_CAPTCHA_KEY");
+    } else {
+      $key = random_int(1000, 9999);
+    }
     $this->setToken($key);    // トークン設定
     $isJa = Config::get('LANG')=='ja'; // 日本語以外は数字のみを表示
     $captcha = new CaptchaImage($size_x, $size_y, Config::get('PASSWORD_SALT'), $isJa);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     container_name: fc2blog-apache
     environment:
       MYSQL_HOST: "db"
+      DEBUG_FORCE_CAPTCHA_KEY: "1234" # デバッグ用にCAPTCHAの値を固定する
     depends_on:
       - db
     working_dir: "/fc2blog/public"

--- a/e2e_test/README.md
+++ b/e2e_test/README.md
@@ -1,6 +1,6 @@
 # E2E test by puppeteer
 
-## setup
+## Setup
 
 ```
 $ npm ci
@@ -10,9 +10,17 @@ $ cp .env.sample .env
 $ vi .env
 ```
 
-## execute
+## Target fc2blog setup
 
-you need start server before.
+- Start target fc2blog webapp.
+- Run `phpunit` for pseudo data set loading.
+
+> Recommend: use docker.
+>
+> If you run at own apache or other, Set `DEBUG_FORCE_CAPTCHA_KEY=1234` ENV.
+
+
+## Execute e2e test
 
 ```
 # All test execution.
@@ -20,5 +28,12 @@ $ npm run test
 
 # or specify a test.
 $ npx jest test/test.test.js
+```
+
+## Don't forget code format before test code commit.
+
+```
+# format by prettier
+$ npm run fmt
 ```
 

--- a/e2e_test/package-lock.json
+++ b/e2e_test/package-lock.json
@@ -1883,6 +1883,13 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        }
       }
     },
     "arr-diff": {
@@ -6396,6 +6403,12 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "26.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
@@ -7356,9 +7369,9 @@
       }
     },
     "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "sshpk": {
       "version": "1.16.1",

--- a/e2e_test/package.json
+++ b/e2e_test/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run clear-cache && npx jest",
+    "fmt": "npx prettier --check --write \"./tests/*.ts\"",
     "clear-cache": "npx jest --clearCache",
     "test-enable-head": "NO_HEAD_LESS=1 npx jest",
     "update-libs": "npx npm-check-updates -u"

--- a/e2e_test/package.json
+++ b/e2e_test/package.json
@@ -21,10 +21,12 @@
     "dotenv": "^8.2.0",
     "jest": "^26.1.0",
     "puppeteer": "^5.2.1",
+    "sprintf-js": "^1.1.2",
     "ts-jest": "^26.1.3",
     "typescript": "^3.9.7"
   },
   "devDependencies": {
-    "npm-check-updates": "^7.0.2"
+    "npm-check-updates": "^7.0.2",
+    "prettier": "2.0.5"
   }
 }

--- a/e2e_test/tests/blog_archive.test.ts
+++ b/e2e_test/tests/blog_archive.test.ts
@@ -1,0 +1,99 @@
+import {afterAll, beforeAll, describe, expect, it} from "@jest/globals";
+import {Helper} from "./helper";
+
+describe("crawl some blog", () => {
+  let c: Helper;
+
+  beforeAll(async () => {
+    c = new Helper();
+    await c.init();
+  });
+
+  const start_url = "http://localhost:8080/testblog2/";
+
+  it("open blog top", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.goto(start_url),
+    ]);
+
+    await c.getSS("blog_top");
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url);
+    expect(await c.page.title()).toEqual("testblog2");
+  });
+
+  it("open archive page", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.click("#headermenu > p > a"),
+    ]);
+
+    await c.getSS("blog_archive.png");
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url + "archives.html");
+
+    expect(await c.page.title()).toEqual("- testblog2"); // TODO 記事一覧などと出るのでは？
+
+    const h2_text = await c.page.$eval(
+        "#titlelist > h2",
+        (elm) => elm.textContent
+    );
+    expect(h2_text.match(/インデックス/)).not.toBeNull();
+
+    const entry_list = await c.page.$$("#titlelist > ul > li");
+    expect(entry_list.length).toEqual(3);
+
+    const link_text = await c.page.$eval(
+        "#titlelist > ul > li:nth-child(1)",
+        (elm) => elm.textContent
+    );
+    expect(
+        link_text.match(/[0-9]{4}\/[0-9]{2}\/[0-9]{2}：3rd：未分類/)
+    ).not.toBeNull();
+  });
+
+  it("open some page", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.click("#titlelist > ul > li:nth-child(1) > a:nth-child(1)"),
+    ]);
+
+    await c.getSS("blog_archive.png");
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url + "?no=3");
+
+    expect(await c.page.title()).toEqual("3rd - testblog2");
+  });
+
+  it("open archive page", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.goto(start_url + "archives.html"),
+    ]);
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url + "archives.html");
+  });
+
+  it("open some category", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.click("#titlelist > ul > li:nth-child(1) > a:nth-child(2)"),
+    ]);
+
+    await c.getSS("blog_category");
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(
+        start_url + "index.php?mode=entries&process=category&cat=1"
+    );
+
+    expect(await c.page.title()).toEqual("未分類 - testblog2");
+  });
+
+  afterAll(async () => {
+    await c.browser.close();
+  });
+});

--- a/e2e_test/tests/blog_crawl.test.ts
+++ b/e2e_test/tests/blog_crawl.test.ts
@@ -1,0 +1,367 @@
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { Helper } from "./helper";
+
+// captcha を完全に動的にするには、ページ内から読み込まれる画像リクエストのヘッダーをいじらないといけないので一旦保留
+// import {sprintf} from 'sprintf-js';
+//
+// // https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Math/random
+// function getRandomInt(min:number, max:number) :number{
+//     min = Math.ceil(min);
+//     max = Math.floor(max);
+//     return Math.floor(Math.random() * (max - min + 1)) + min; //The maximum is inclusive and the minimum is inclusive
+// }
+//
+// function generateRandomCaptchaKey():string{
+//     return sprintf("%04d", getRandomInt(1000,9999));
+// }
+// await c.page.setExtraHTTPHeaders({
+//     "x-debug-force-captcha-key": captcha_key
+// });
+
+describe("crawl some blog", () => {
+  let c: Helper;
+  let captcha_key: string;
+
+  beforeAll(async () => {
+    c = new Helper();
+    await c.init();
+    captcha_key = "1234";
+  });
+
+  const start_url = "http://localhost:8080/testblog2/";
+
+  it("open blog top", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.goto(start_url),
+    ]);
+
+    await c.getSS("blog_top.png");
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url);
+    expect(await c.page.title()).toEqual("testblog2");
+  });
+
+  it("check cookie", async () => {
+    const cookies = await c.page.cookies();
+
+    // ここがコケるということは、テスト無しにクッキーが追加されているかも
+    expect(cookies.length).toEqual(2);
+
+    const [session_cookie] = cookies.filter((elm) => elm.name === "dojima");
+    const [template_cookie] = cookies.filter(
+      (elm) => elm.name === "template_blog_fc2"
+    );
+
+    // console.log(session_cookie);
+    expect(session_cookie.domain).toEqual("localhost");
+    expect(session_cookie.path).toEqual("/");
+    expect(session_cookie.expires).toEqual(-1);
+    expect(session_cookie.httpOnly).toEqual(true);
+    expect(session_cookie.secure).toEqual(false);
+    expect(session_cookie.session).toEqual(true);
+    expect(session_cookie.sameSite).toEqual("Lax");
+
+    // console.log(template_cookie);
+    expect(template_cookie.value).toEqual("glid");
+    expect(template_cookie.domain).toEqual("localhost");
+    expect(template_cookie.path).toEqual("/testblog2");
+    expect(template_cookie.expires).toEqual(-1);
+    expect(template_cookie.httpOnly).toEqual(false);
+    expect(template_cookie.secure).toEqual(false);
+    expect(template_cookie.session).toEqual(true);
+    expect(template_cookie).not.toHaveProperty("sameSite");
+  });
+
+  it("check fuzzy display contents", async () => {
+    const title_text = await c.page.$eval("h1 a", (elm) => elm.innerHTML);
+    expect(title_text).toEqual("testblog2");
+
+    const entry_bodies = await c.page.$$eval("div.entry_body", (elm_list) => {
+      let bodies = [];
+      elm_list.forEach((elm) => bodies.push(elm.textContent));
+      return bodies;
+    });
+    // console.log(entry_bodies);
+
+    expect(entry_bodies[0].match(/3rd/)).toBeTruthy();
+    expect(entry_bodies[1].match(/2nd/)).toBeTruthy();
+    expect(entry_bodies[2].match(/1st/)).toBeTruthy();
+  });
+
+  it("click  first entry's 「続きを読む」", async () => {
+    const link = await c.page.$("div.entry_body a");
+
+    const [response] = await Promise.all([c.waitLoad(), link.click()]);
+
+    await c.getSS("entry.png");
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url + "?no=3");
+    expect(await c.page.title()).toEqual("3rd - testblog2");
+
+    const entry_h2_title = await c.page.$eval(
+      "h2.entry_header",
+      (elm) => elm.textContent
+    );
+    const entry_body = await c.page.$eval(
+      "div.entry_body",
+      (elm) => elm.textContent
+    );
+
+    expect(entry_body.match(/3rd/)).toBeTruthy();
+    expect(entry_h2_title.match(/3rd/)).toBeTruthy();
+  });
+
+  it("next page", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.click("a.nextentry"),
+    ]);
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url + "?no=2");
+    expect(await c.page.title()).toEqual("2nd - testblog2");
+
+    const entry_h2_title = await c.page.$eval(
+      "h2.entry_header",
+      (elm) => elm.textContent
+    );
+    const entry_body = await c.page.$eval(
+      "div.entry_body",
+      (elm) => elm.textContent
+    );
+
+    expect(entry_body.match(/2nd/)).toBeTruthy();
+    expect(entry_h2_title.match(/2nd/)).toBeTruthy();
+  });
+
+  it("prev page", async () => {
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      c.page.click("a.preventry"),
+    ]);
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url + "?no=3");
+    expect(await c.page.title()).toEqual("3rd - testblog2");
+
+    const entry_h2_title = await c.page.$eval(
+      "h2.entry_header",
+      (elm) => elm.textContent
+    );
+    const entry_body = await c.page.$eval(
+      "div.entry_body",
+      (elm) => elm.textContent
+    );
+
+    expect(entry_body.match(/3rd/)).toBeTruthy();
+    expect(entry_h2_title.match(/3rd/)).toBeTruthy();
+  });
+
+  it("comment", async () => {
+    expect(
+      (await c.page.$eval("#cm h3.sub_header", (elm) => elm.textContent)).match(
+        /コメント/
+      )
+    ).toBeTruthy();
+    expect(
+      (
+        await c.page.$eval(
+          "#cm div.form h4.sub_title",
+          (elm) => elm.textContent
+        )
+      ).match(/コメントの投稿/)
+    ).toBeTruthy();
+
+    await c.page.type(
+      "#comment_form input[name='comment[name]']",
+      "テスト太郎"
+    );
+    await c.page.type(
+      "#comment_form input[name='comment[title]']",
+      "テストタイトル"
+    );
+    await c.page.type(
+      "#comment_form input[name='comment[mail]']",
+      "test@example.jp"
+    );
+    await c.page.type(
+      "#comment_form input[name='comment[url]']",
+      "http://example.jp"
+    );
+    await c.page.type(
+      "#comment_form textarea[name='comment[body]']",
+      "これはテスト投稿です\nこれはテスト投稿です！"
+    );
+    await c.page.type(
+      "#comment_form input[name='comment[pass]']",
+      "pass_is_pass"
+    );
+
+    await c.getSS("comment_filled.png");
+
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      await c.page.click("#comment_form input[type=submit]"),
+    ]);
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url);
+
+    await c.getSS("comment_confirm.png");
+  });
+
+  it("failed with wrong captcha", async () => {
+    // input wrong captcha
+    await c.page.type("input[name=token]", "0000"); // wrong key
+
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      await c.page.click("#sys-comment-form input[type=submit]"),
+    ]);
+
+    expect(response.status()).toEqual(200);
+    expect(response.url()).toEqual(start_url);
+
+    await c.getSS("comment_wrong_captcha.png");
+
+    // 特定しやすいセレクタがない
+    const is_captcha_failed = await c.page.$$eval("p", (elms) => {
+      let isOk = false;
+      elms.forEach((elm) => {
+        if (elm.textContent.match(/認証に失敗しました/)) {
+          isOk = true;
+        }
+      });
+      return isOk;
+    });
+
+    expect(is_captcha_failed).toBeTruthy();
+  });
+
+  it("comment success", async () => {
+    await c.page.type("input[name=token]", captcha_key);
+    await c.getSS("comment_success.png");
+
+    const [response] = await Promise.all([
+      c.waitLoad(),
+      await c.page.click("#sys-comment-form input[type=submit]"),
+    ]);
+
+    await c.getSS("comment_success.png");
+
+    expect(response.status()).toEqual(200);
+    const exp = new RegExp(
+      start_url + "index.php\\?mode=entries&process=view&id=[0-9]{1,100}"
+    );
+    expect(response.url().match(exp)).not.toBeNull();
+  });
+
+  it("comment edit", async () => {
+    // NOTE: html構造的に、「編集」リンクが探しづらい
+    let [response] = await Promise.all([
+      c.waitLoad(),
+      await c.page.click("#cm #comment1 > ul > li:nth-child(3) > a"),
+    ]);
+
+    expect(response.status()).toEqual(200);
+
+    await c.page.$eval(
+      "#comment_form input[name='edit[name]']",
+      (elm: HTMLInputElement) => (elm.value = "")
+    );
+    await c.page.type("#comment_form input[name='edit[name]']", "テスト太郎2");
+    await c.page.$eval(
+      "#comment_form input[name='edit[title]']",
+      (elm: HTMLInputElement) => (elm.value = "")
+    );
+    await c.page.type(
+      "#comment_form input[name='edit[title]']",
+      "テストタイトル2"
+    );
+    await c.page.$eval(
+      "#comment_form input[name='edit[mail]']",
+      (elm: HTMLInputElement) => (elm.value = "")
+    );
+    await c.page.type(
+      "#comment_form input[name='edit[mail]']",
+      "test@example.jp2"
+    );
+    await c.page.$eval(
+      "#comment_form input[name='edit[url]']",
+      (elm: HTMLInputElement) => (elm.value = "")
+    );
+    await c.page.type(
+      "#comment_form input[name='edit[url]']",
+      "http://example.jp/2"
+    );
+    await c.page.$eval(
+      "#comment_form textarea[name='edit[body]']",
+      (elm: HTMLInputElement) => (elm.value = "")
+    );
+    await c.page.type(
+      "#comment_form textarea[name='edit[body]']",
+      "これは編集済み"
+    );
+    await c.page.$eval(
+      "#comment_form input[name='edit[pass]']",
+      (elm: HTMLInputElement) => (elm.value = "")
+    );
+    await c.page.type("#comment_form input[name='edit[pass]']", "pass_is_pass");
+
+    await c.getSS("comment_edit_page.png");
+
+    // 保存する
+    [response] = await Promise.all([
+      c.waitLoad(),
+      await c.page.click("#comment_form > p > input[type=submit]:nth-child(1)"),
+    ]);
+
+    await c.getSS("comment_edit_confirm.png");
+    expect(response.status()).toEqual(200);
+
+    await c.page.type("input[name=token]", captcha_key);
+
+    [response] = await Promise.all([
+      c.waitLoad(),
+      await c.page.click("#sys-comment-form input[type=submit]"),
+    ]);
+
+    await c.getSS("comment_edit_success.png");
+    expect(response.status()).toEqual(200);
+  });
+
+  // WIP、削除機能がうごいていないので。
+  it("comment delete", async () => {
+    const comment1 = await c.page.$("#comment1");
+    const title = await comment1.$eval(
+      "h4.sub_title",
+      (elm) => elm.textContent
+    );
+    const edit_a = await c.page.$("#comment1 > ul > li:nth-child(3) > a");
+
+    // NOTE: html構造的に、「編集」リンクが探しづらい
+    let [response] = await Promise.all([c.waitLoad(), await edit_a.click()]);
+
+    expect(response.status()).toEqual(200);
+
+    const h3_test = await c.page.$eval("#edit > h3.sub_header", (elm) => {
+      return elm.textContent;
+    });
+    expect(h3_test.match(/コメントの編集/)).toBeTruthy();
+
+    const delete_button = await c.page.$(
+      "#comment_form > p > input[type=submit]:nth-child(2)"
+    );
+
+    [response] = await Promise.all([c.waitLoad(), await delete_button.click()]);
+
+    // TODO 削除機能がうごいていないので完成と言えない
+  });
+
+  afterAll(async () => {
+    await c.browser.close();
+  });
+});

--- a/e2e_test/tests/helper.ts
+++ b/e2e_test/tests/helper.ts
@@ -1,74 +1,72 @@
 import puppeteer = require("puppeteer");
-import dotenv = require('dotenv');
+import dotenv = require("dotenv");
 import * as process from "process";
-import {Browser, Page, Response} from "puppeteer";
+import { Browser, Page, Response } from "puppeteer";
 
 dotenv.config();
 
 export class Helper {
+  page: Page;
+  browser: Browser;
 
-    page: Page;
-    browser: Browser;
+  constructor() {}
 
-    constructor() {
-    }
+  getBaseUrl(): string {
+    return process.env.BASE_URL || "https://localhost:8480/";
+  }
 
-    getBaseUrl(): string {
-        return process.env.BASE_URL || "https://localhost:8480/";
-    }
+  async init(): Promise<void> {
+    this.browser = await puppeteer.launch({
+      ignoreHTTPSErrors: true,
+      headless: !(process.env.NO_HEAD_LESS === "1"), // 動作を確認するなら NO_HEAD_LESS=1 npm run test
+    });
+    this.page = await this.browser.newPage();
+    await this.page.authenticate({
+      username: process.env.BASIC_ID || "",
+      password: process.env.BASIC_PASS || "",
+    });
+    // memo 環境によってはスクショ作成のためにViewportが大きくしすぎると一部テストが正しく動作しない?
+    await this.page.setViewport({
+      width: 1000,
+      height: parseInt(process.env.VIEW_PORT_HEIGHT) || 1000,
+    });
+  }
 
-    async init(): Promise<void> {
-        this.browser = await puppeteer.launch({
-            ignoreHTTPSErrors: true,
-            headless: !(process.env.NO_HEAD_LESS === "1") // 動作を確認するなら NO_HEAD_LESS=1 npm run test
-        });
-        this.page = await this.browser.newPage();
-        await this.page.authenticate({
-            username: process.env.BASIC_ID || '',
-            password: process.env.BASIC_PASS || ''
-        });
-        // memo 環境によってはスクショ作成のためにViewportが大きくしすぎると一部テストが正しく動作しない?
-        await this.page.setViewport({width: 1000, height: parseInt(process.env.VIEW_PORT_HEIGHT) || 1000});
-    }
+  async getTitle(): Promise<string> {
+    return await this.page.title();
+  }
 
-    async getTitle(): Promise<string> {
-        return await this.page.title();
-    }
+  waitDom(): Promise<Response> {
+    return this.page.waitForNavigation({ waitUntil: "domcontentloaded" });
+  }
 
-    waitDom(): Promise<Response> {
-        return this.page.waitForNavigation({waitUntil: 'domcontentloaded'});
-    }
+  waitLoad(): Promise<Response> {
+    return this.page.waitForNavigation({ waitUntil: ["load", "networkidle2"] });
+  }
 
-    waitLoad(): Promise<Response> {
-        return this.page.waitForNavigation({waitUntil: ['load', 'networkidle2']});
-    }
+  async getSS(name): Promise<void> {
+    await this.page.screenshot({ path: "ss/" + name + ".png" });
+  }
 
-    async getSS(name): Promise<void> {
-        await this.page.screenshot({path: 'ss/' + name + ".png"});
-    }
+  async click(selector): Promise<void> {
+    return await this.page.click(selector);
+  }
 
-    async click(selector): Promise<void> {
-        return await this.page.click(selector);
-    }
+  async clickAndWaitResponse(selector): Promise<Response> {
+    let some = await Promise.all([this.waitLoad(), this.page.click(selector)]);
 
-    async clickAndWaitResponse(selector): Promise<Response> {
-        let some = await Promise.all([
-            this.waitLoad(),
-            this.page.click(selector)
-        ]);
+    return some[0];
+  }
 
-        return some[0];
-    }
+  async isExists(selector): Promise<boolean> {
+    const elms = await this.page.$$(selector);
+    return elms.length > 0;
+  }
 
-    async isExists(selector): Promise<boolean> {
-        const elms = await this.page.$$(selector);
-        return elms.length > 0;
-    }
-
-    async setCheckBox(selector): Promise<void> {
-        await Promise.all([
-            this.page.$eval(selector, elem => (elem as HTMLElement).click()),
-            this.page.waitForSelector(selector)
-        ]);
-    }
+  async setCheckBox(selector): Promise<void> {
+    await Promise.all([
+      this.page.$eval(selector, (elem) => (elem as HTMLElement).click()),
+      this.page.waitForSelector(selector),
+    ]);
+  }
 }

--- a/e2e_test/tests/open_base_url.test.ts
+++ b/e2e_test/tests/open_base_url.test.ts
@@ -1,27 +1,27 @@
-import {afterAll, beforeAll, describe, expect, it} from "@jest/globals";
-import {Helper} from './helper';
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import { Helper } from "./helper";
 
-describe('will be redirect to random blog page', () => {
-    let c: Helper;
+describe("will be redirect to random blog page", () => {
+  let c: Helper;
 
-    beforeAll(async () => {
-        c = new Helper();
-        await c.init();
-    });
+  beforeAll(async () => {
+    c = new Helper();
+    await c.init();
+  });
 
-    it('redirect to random blog page', async () => {
-        const response = await c.page.goto(c.getBaseUrl());
-        const redirect = response.request().redirectChain()[0];
-        expect(redirect.url()).toEqual(c.getBaseUrl());
-        expect(redirect.response().headers().location).toMatch(/\/testblog[0-9]\//);
-        expect(response.status()).toEqual(200);
-    });
+  it("redirect to random blog page", async () => {
+    const response = await c.page.goto(c.getBaseUrl());
+    const redirect = response.request().redirectChain()[0];
+    expect(redirect.url()).toEqual(c.getBaseUrl());
+    expect(redirect.response().headers().location).toMatch(/\/testblog[0-9]\//);
+    expect(response.status()).toEqual(200);
+  });
 
-    it('get Title after redirected page.', async () => {
-        expect(await c.getTitle()).toMatch(/testblog/);
-    });
+  it("get Title after redirected page.", async () => {
+    expect(await c.getTitle()).toMatch(/testblog/);
+  });
 
-    afterAll(async () => {
-        await c.browser.close();
-    });
+  afterAll(async () => {
+    await c.browser.close();
+  });
 });

--- a/e2e_test/tests/test.test.ts
+++ b/e2e_test/tests/test.test.ts
@@ -1,4 +1,4 @@
 // testのテスト
-test('1 = 1', () => {
-    expect(1).toBe(1);
+test("1 = 1", () => {
+  expect(1).toBe(1);
 });


### PR DESCRIPTION
#31 より

固定データ（phpunitにて生成されるデータ）を前提として、フロント側のページをクロールし、Status code 500などがでないことを確認します。

> #44 でみつけましたが、コメント削除が動作しておらず？完全ではありません。

ただ、現状でも単純にブログが動作することは確認でき、リファクタ時に壊れていないかなどの自動テストには十分役立ちます。他のバグ修正も行いつつテストを育てたいので、大まかな方向が違えていなければ、一旦はマージできればと思いま。

（あるいは、フロント側表示で「ここはクリティカルだからチェックしたい」というのがあれば、コメント下さい）

- ブログを開く
- エントリの前後エントリに移動
- コメントを書く
- コメントを再編集する
- コメントを削除する（削除が動作していない？ので未完成）
- 記事一覧(archives.html)表示
- カテゴリインデックス表示

## note Captchaトークンの固定化手法について

性質上、ウェブページアクセス時の「後」にcaptcha画像がDLされ、tokenが確定します。

「セッション全体で統一」な固定captchaは実装できますが、正しく「ページロード毎の画像リクエスト時に」token固定はすこし凝った事をする必要があるので、一旦実装を避けました。

キーを指定する`DEBUG_FORCE_CAPTCHA_KEY`環境変数をリモートから設定することはできないので（そして、Prodでは指定しないので）Captchaに対するテストが多少減った程度かと思われます。追って実装できればと思います。

(工数 1日
