### PR TITLE
[#63を参照ください]Fix: 削除ボタンはcaptchaのない画面に設置されており、captcha確認処理より前に必要

### DIFF
--- a/app/controller/user/entries_controller.php
+++ b/app/controller/user/entries_controller.php
@@ -738,6 +738,11 @@ class EntriesController extends UserController
       return $this->fc2template($blog_id);
     }
 
+    // 削除ボタンを押された場合の処理
+    if ($request->get('comment.delete')) {
+      return $this->comment_delete();
+    }
+
     // Captcha画面の初期表示処理
     if ($is_captcha && !$request->isArgs('token')) {
       return ;
@@ -746,11 +751,6 @@ class EntriesController extends UserController
     // FC2テンプレート編集時
     if (!$is_captcha) {
       $this->set('edit_comment', $request->get('comment'));
-    }
-
-    // 削除ボタンを押された場合の処理
-    if ($request->get('comment.delete')) {
-      return $this->comment_delete();
     }
 
     // コメント投稿処理


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/870716/89534858-8f27c700-d830-11ea-9edd-51c8f238607d.png)

この画面において、削除ボタンが動作しないのを修正。
(テンプレート側の問題かとおもったが、masterブランチ管理画面でテンプレート再生成しても再現)

`comment_edit()`はcaptchaがただしいか検証しているが、この画面にはcaptchaはないのでロジックの順序を変更した。

あるいは、以下の画面に削除ボタンを持ってくる必要があると考える。

![image](https://user-images.githubusercontent.com/870716/89534981-baaab180-d830-11ea-8c40-7f7dd4a1e83b.png)

（ただ、コメント削除にはcaptchaはいらないのではないか？と思われる、ご検討ください）

(作業時間 1時間