### PR TITLE
[#63を参照ください]Fix: 管理画面などの言語切替が正しく動作していなかったのを修正、Cookieのpath指定ミス

### DIFF
--- a/app/core/cookie.php
+++ b/app/core/cookie.php
@@ -46,7 +46,7 @@ class Cookie
   public static function set(string $key,
                              string $value,
                              int $expires = 0,
-                             string $path = "",
+                             string $path = "/",
                              string $domain = "",
                              bool $secure = false,
                              bool $httponly = true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/870716/89558128-cd33e380-d84e-11ea-88f1-57c41d9e2fca.png)

管理ページ下部の言語指定変更時に適切にきりかわらないバグ

- 都度pathを指定する設計でライブラリを更新したが、特に管理画面の設計実情として省略時は`/`を期待しているために変更

