### PR TITLE
[#63を参照ください]コメント投稿確認画面にて、正しいタイトルを挿入する

### DIFF
--- a/app/view/user/layouts/default.html
+++ b/app/view/user/layouts/default.html
@@ -4,10 +4,10 @@ if(!headers_sent()){
 }
 ?>
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="<?php echo Config::get('LANG'); ?>">
 <head>
   <meta charset="utf-8">
-  <title>サイト名</title>
+  <title><?php echo h($blog['name']); ?></title>
   <link rel="stylesheet" href="/css/normalize.css" type="text/css" media="all">
   <link rel="stylesheet" href="/css/user-fc2.css" type="text/css" media="all">
   <link rel="stylesheet" href="/css/user-form.css" type="text/css" media="all">

--- a/app/view/user/layouts/default_sp.html
+++ b/app/view/user/layouts/default_sp.html
@@ -1,4 +1,8 @@
-<?php header("Content-Type: text/html; charset=UTF-8"); ?>
+<?php
+if(!headers_sent()){
+  header("Content-Type: text/html; charset=UTF-8");
+}
+?>
 <!DOCTYPE html>
 <html lang="<?php echo Config::get('LANG'); ?>">
 <head>
@@ -6,7 +10,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
   <meta content="telephone=no" name="format-detection" />
   <meta name="robots" content="noindex, nofollow, noarchive" />
-  <title><?php echo Session::get('blog_id'); ?></title>
+  <title><?php echo h($blog['name']); ?></title>
   <link rel="stylesheet" href="/css/sp/blog_sp_admin.css" type="text/css" media="all">
   <link rel="stylesheet" href="/css/sp/side_menu.css" type="text/css" media="all">
   <link rel="stylesheet" href="/css/sp/blog_comment_sp.css" type="text/css" media="all">


### PR DESCRIPTION
ref: #43

(PCテンプレの出力HTML)
![image](https://user-images.githubusercontent.com/870716/89705293-1bec9500-d997-11ea-8828-824b1a2807d9.png)

- PCテンプレートは「サイト名」となっていたのを修正
- PCテンプレートはLanguage指定がja固定だったのをSPを参考にConfigから読み込むように修正
- SPテンプレートはブログ名（`$blog['name']`）でなく、blog idを表示していたので、blog名に修正

## Note:
元が「サイト名」だったのでサイト名だけにしましたが、「コメントを投稿する - {サイト名}」や、「コメント投稿確認画面 - {サイト名}」がふさわしいようにも見えます。
ご検討ください。

（作業時間 1h）