### PR TITLE
[#63を参照ください]開発用Dockerにxdebug拡張の追加

### DIFF
--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -9,10 +9,10 @@ RUN set -eux \
  && docker-php-ext-configure gd --with-jpeg=/usr --with-freetype=/usr \
  && docker-php-ext-configure opcache --enable-opcache \
  && docker-php-ext-install opcache bcmath pdo_mysql gd exif zip gettext intl \
+ && pecl install xdebug \
+ && docker-php-ext-enable xdebug \
  && rm -rf /tmp/*
 
 RUN a2enmod rewrite \
  && a2enmod ssl \
  && a2ensite default-ssl
-
-


### PR DESCRIPTION
そろそろコードの確認のためにxdebugが必要になりましたので追加しました。

有効化する仕組みについては、別途のプルリクがマージされてからなんらか仕組みを用意する予定です。
（追加の.iniをini scan dirに追加する方法になるかと思います）

`xdebug.remote_enable`が`PHP_INI_PERDIR`なので、別のdockerが絡むプルリクがマージされてからなんらかスイッチ機構を追加する予定です。取り急ぎ使う場合には、`public/.htaccess`に以下を追記します。

```
# 例です
php_value xdebug.remote_enable On
php_value xdebug.remote_autostart On
php_value xdebug.remote_host host.docker.internal
php_value xdebug.remote_port 9000
php_value xdebug.var_display_max_children -1
php_value xdebug.var_display_max_data -1
php_value xdebug.var_display_max_depth -1
```

（反映には`docker-composer build`が必要ですが、xdebugをつかわないかぎりは不要です）

（作業時間ゼロ
