### PR TITLE
カレンダーおよびブログ設定画面のwarning修正

### DIFF
--- a/app/controller/admin/blog_settings_controller.php
+++ b/app/controller/admin/blog_settings_controller.php
@@ -61,7 +61,8 @@ class BlogSettingsController extends AdminController
       // コメント確認からコメントを確認せずそのまま表示に変更した場合既存の承認待ちを全て承認済みに変更する
       $blog_setting = $blog_settings_model->findByBlogId($blog_id);
       if ($blog_setting['comment_confirm'] == Config::get('COMMENT.COMMENT_CONFIRM.CONFIRM')
-        && $blog_setting_data['comment_confirm'] == Config::get('COMMENT.COMMENT_CONFIRM.THROUGH')
+          && isset($blog_setting_data['comment_confirm'])
+          && $blog_setting_data['comment_confirm'] == Config::get('COMMENT.COMMENT_CONFIRM.THROUGH')
       ) {
         Model::load('Comments')->updateApproval($blog_id);
       }

--- a/app/model/entries_model.php
+++ b/app/model/entries_model.php
@@ -413,7 +413,7 @@ SQL;
       'fields' => 'DAY(posted_at) as day',
       'where'  => 'blog_id=? AND ? <= posted_at AND posted_at <= ?',
       'params' => array($blog_id, date('Y-m-01 00:00:00', $timestamp), date('Y-m-t 23:59:59', $timestamp)),
-      'group'  => 'DAY(posted_at)',
+      'group'  => 'DAY(posted_at), posted_at',
       'order'  => 'posted_at ASC',
     );
     $days = $this->find('all', $options);


### PR DESCRIPTION
- カレンダー
`Warning: Invalid argument supplied for foreach() in /var/www/app/model/entries_model.php on line 422`
上記warningの修正
→ 発行されるSQLに不具合があり、一件も取れていないのが原因でしたのでこちらを修正いたしました。

- ブログ設定画面
`Notice: Undefined index: comment_confirm in /var/www/app/controller/admin/blog_settings_controller.php on line 64`
上記warningの修正
→定義されていないキーを参照するとwarningが出ますので、定義されているかチェックを入れました。