### PR TITLE
[#63を参照ください]管理画面ログアウトに失敗するのを修正（#50を先にマージしてください）

### DIFF
--- a/app/core/cookie.php
+++ b/app/core/cookie.php
@@ -20,14 +20,11 @@ class Cookie
   /**
    * クッキーから情報を取得し破棄する
    * @param string $key
-   * @param string|null $default
-   * @return string|null
+   * @return void
    */
-  public static function remove(string $key, string $default = null)
+  public static function remove(string $key):void
   {
-    $value = self::get($key, $default);
-    self::set($key, null, time() - 3600);
-    return $value;
+    self::set($key, "", time() - 3600);
   }
 
   /**

--- a/app/core/cookie.php
+++ b/app/core/cookie.php
@@ -46,7 +46,7 @@ class Cookie
   public static function set(string $key,
                              string $value,
                              int $expires = 0,
-                             string $path = "",
+                             string $path = "/",
                              string $domain = "",
                              bool $secure = false,
                              bool $httponly = true,


### PR DESCRIPTION
#50 のブランチから伸ばしたプルリクになるため、 #50 を先にマージお願いいたします。

- Cookie::remove()で「最後の値」をかえさないように挙動変更
- 挙動が変わったが、現在のコードにおいては問題にならない