### PR TITLE
Experimental：配布用zipの生成スクリプトとそのサンプル

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /dump_data.sql
 /dump_all.sql
 /dump_schema.sql
+/fc2blog-dist*.zip

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build-dist-zip:
 	chmod 777 $(tmpdir)/public/uploads/
 	rm -r $(tmpdir)/public/_for_unit_test_
 	rm -r $(tmpdir)/public/.htaccess
-	cp -r app/resource/apache/.htaccess.production $(tmpdir)/public/.htaccess
+	cp -r app/docs/apache/.htaccess.production $(tmpdir)/public/.htaccess
 	cp LICENSE.txt README.md $(tmpdir)/app
 	zip -r $(tmpdir).zip $(tmpdir)
 	rm -r $(tmpdir)

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ build-dist-zip:
 	mkdir $(tmpdir)
 	composer install --no-dev --optimize-autoloader
 	cp -a app $(tmpdir)
+	cp LICENSE.txt $(tmpdir)/app
 	rm -r $(tmpdir)/app/temp/*
 	chmod 777 $(tmpdir)/app/temp/
 	cp -a public $(tmpdir)

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,25 @@ db-dump-all:
 .PHONY: db-dump-data-only
 db-dump-data-only:
 	mysqldump -u docker -pdocker -h 127.0.0.1 -P 3306 --complete-insert --skip-extended-insert --column-statistics=0 --skip-triggers --no-create-db --no-create-info "dev_fc2blog" | sed "s/ AUTO_INCREMENT=[0-9]*//" > dump_data.sql
+
+.PHONY: build-dist-zip
+build-dist-zip:
+	find app public |grep .DS_Store |xargs rm
+	$(eval date := $(shell date "+%Y%m%d%H%M%S")-$(shell git rev-parse --short HEAD))
+	$(eval tmpdir := fc2blog-dist-$(date))
+	mkdir $(tmpdir)
+	composer install --no-dev --optimize-autoloader
+	cp -a app $(tmpdir)
+	rm -r $(tmpdir)/app/temp/*
+	chmod 777 $(tmpdir)/app/temp/
+	cp -a public $(tmpdir)
+	rm -r $(tmpdir)/public/uploads/*
+	chmod 777 $(tmpdir)/public/uploads/
+	rm -r $(tmpdir)/public/_for_unit_test_
+	rm -r $(tmpdir)/public/.htaccess
+	cp -r app/resource/apache/.htaccess.production $(tmpdir)/public/.htaccess
+	cp LICENSE.txt README.md $(tmpdir)/app
+	zip -r $(tmpdir).zip $(tmpdir)
+	rm -r $(tmpdir)
+	composer install
+	echo "build $(tmpdir).zip successfully"

--- a/app/docs/DEPLOY_ubuntu20.04.md
+++ b/app/docs/DEPLOY_ubuntu20.04.md
@@ -21,6 +21,7 @@ $ sudo su
 ## mysql
 ```
 $ sudo mysql_secure_installation
+$ sudo mysql -u root
 > create user 'fc2blog'@'localhost' identified by 'topsecretpasswordforyoursafe';
 > grant all on fc2blog.* to 'fc2blog'@'localhost' with grant option;
 > flush privileges;

--- a/app/docs/DEPLOY_ubuntu20.04.md
+++ b/app/docs/DEPLOY_ubuntu20.04.md
@@ -1,0 +1,48 @@
+# Ubuntu 20.04 最短構築
+
+## 初期Linux設定
+```
+$ sudo su
+# apt -y update && apt -y upgrade && shutdown -r now
+
+$ sudo su
+# ufw allow 22
+# ufw allow 80
+# ufw allow 443
+# ufw enable
+# ufw status
+# timedatectl set-timezone Asia/Tokyo
+# apt -y install apache2 php-mysql php-mbstring php-gd php-curl php-intl php-zip mysql-server php7.4 unzip
+# apt -y install language-pack-ja-base language-pack-ja
+# locale -a
+(ja_JP.UTF-8の確認)
+```
+
+## mysql
+```
+$ sudo mysql_secure_installation
+> create user 'fc2blog'@'localhost' identified by 'topsecretpasswordforyoursafe';
+> grant all on fc2blog.* to 'fc2blog'@'localhost' with grant option;
+> flush privileges;
+> exit
+```
+
+## deploy
+```
+$ cd
+$ wget http://github.com/..../fc2blog-dist-XXX.zip (例
+$ unzip fc2blog-dist-XXX.zip
+$ sudo su
+# cp -a fc2blog-dist-XXX/* /var/www
+# cp fc2blog-dist-XXX/app/resource/apache/100-fc2blog.conf /etc/apache2/sites-available/
+# vi /etc/apache2/sites-available/100-fc2blog.conf
+# a2dissite 000-default.conf
+# a2ensite 100-fc2blog.conf
+# a2enmod rewrite
+# systemctl restart apache2
+
+# cp /var/www/app/config.sample.php /var/www/app/config.php
+# vi  /var/www/app/config.php
+```
+
+`http://{ホスト}/install.php` を開く

--- a/app/docs/apache/.htaccess.production
+++ b/app/docs/apache/.htaccess.production
@@ -1,0 +1,18 @@
+## ログ設定
+### エラーを画面に表示する、可能ならば本番時はコメントアウト推奨
+#php_value display_errors on
+#php_value display_startup_errors On
+#php_value error_reporting -1
+### エラーをログする、本番時も有効化推奨
+php_value log_errors On
+
+## mod_rewirte 設定、通常修正不要
+RewriteEngine On
+RewriteBase /
+
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule . - [L]
+
+RewriteRule . index.php [L]
+

--- a/app/docs/apache/100-fc2blog.conf
+++ b/app/docs/apache/100-fc2blog.conf
@@ -1,0 +1,14 @@
+<VirtualHost *:80>
+    ServerName www.example.com
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/public
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    <Directory /var/www/public>
+        Options FollowSymlinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>


### PR DESCRIPTION
これはウェブアプリ配布用のzipパッケージをつくるための実験の一環です。（方向性の確認をいただくためのもので、急ぎでマージは不要です）

- [fc2blog-dist-20200830100757-8278988.zip](https://github.com/fc2blog/blog/files/5146178/fc2blog-dist-20200830100757-8278988.zip)

配布用の（開発用のテストなどを含まない）zipファイルの構造を検討しています。上記はサンプルです。
手元のUbuntu 20では、このzipにふくまれる、appとpublicのみで動作を確認しています。

```
$ make build-dist-zip
```

でzipを生成でき、一般ユーザーにはこれを配布すると良いのではないかと思います。

なお、このzipをもちいたデプロイ手順例を
https://github.com/fc2blog/blog/commit/827898836fbd97ac3a3f7bb3cd01599ec0ea0c08?short_path=bd9442d#diff-bd9442d62d8740910ace1fc112d3da08
に書いてみました。

まだざっくりしているのでmakeでビルドしていますし、配布物にドキュメントをもうちょっと入れたほうが良いとおもいますが、こういった配布形態でいかがでしょうか。レンサバでも解凍したappとpublicを適切におけば動くと思います。

これを将来的にはCIで回して、リリース番号をうつたびに生成できればと思います。（そして一般ユーザーにはこっちを使ってもらう方がよいでしょう）

## 展望
これをベースに、ansibleをかいて、Ubuntu環境での自動構築を作り上げ、それをAMIにできればと思います。
また、 #39 もこれをベースに上書きするような形を考えています。

（作業時間 3h