### PR TITLE
バグ修正: 管理画面にて、ajax_approve、ajax_reply周りが壊れていたのを修正

### DIFF
--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -140,8 +140,9 @@ class CategoriesController extends AdminController
   /**
    * ajax用のカテゴリ追加
    * @param Request $request
+   * @return string
    */
-  public function ajax_add(Request $request)
+  public function ajax_add(Request $request): string
   {
     /** @var CategoriesModel $categories_model */
     $categories_model = Model::load('Categories');
@@ -150,8 +151,11 @@ class CategoriesController extends AdminController
 
     $json = array('status' => 0);
 
-    if (!Session::get('sig') || Session::get('sig') !== $request->get('sig')) {
-      return;
+    if (!$request->isValidSig()) {
+      $this->set('http_content_type', "application/json; charset=utf-8");
+      $this->set('http_status_code', 400);
+      $this->set('json', ['error' => 'invalid sig']);
+      return "admin/common/json.twig";
     }
 
     $category_request = $request->get('category');
@@ -171,8 +175,9 @@ class CategoriesController extends AdminController
 
     $json['error'] = $errors;
 
-    $this->layout = 'json.php';
+    $this->set('http_content_type', "application/json; charset=utf-8");
     $this->set('json', $json);
+    return "admin/common/json.twig";
   }
 
 }

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -177,9 +177,9 @@ class FilesController extends AdminController
 
   /**
    *編集
-* @param Request $request
-* @return string
-*/
+   * @param Request $request
+   * @return string
+   */
   public function edit(Request $request): string
   {
     $files_model = new FilesModel();
@@ -278,8 +278,9 @@ class FilesController extends AdminController
   /**
    * 削除
    * @param Request $request
+   * @return string
    */
-  public function ajax_delete(Request $request)
+  public function ajax_delete(Request $request): string
   {
     // 削除処理
     $json = array('status' => 0);
@@ -287,8 +288,9 @@ class FilesController extends AdminController
       $json = array('status' => 1);
     }
 
-    $this->layout = 'json.php';
+    $this->set('http_content_type', "application/json; charset=utf-8");
     $this->set('json', $json);
+    return "admin/common/json.twig";
   }
 
 }

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -71,6 +71,16 @@ abstract class Controller
 
   public function emit()
   {
+    $status_code = isset($this->data['http_status_code']) ? $this->data['http_status_code'] : 200;
+    if($status_code !== 200){
+      http_response_code($status_code);
+    }
+
+    $content_type = isset($this->data['http_content_type']) ? $this->data['http_content_type'] : "";
+    if(strlen($content_type)>0){
+      header("Content-Type: {$content_type}");
+    }
+
     echo $this->output;
   }
 

--- a/app/twig_templates/admin/common/json.twig
+++ b/app/twig_templates/admin/common/json.twig
@@ -1,0 +1,1 @@
+{{ json|json_encode()|raw }}


### PR DESCRIPTION
許可操作後に正しい遷移（ラベルが消えるなど）をしていなかったバグを修正

- admin/comments/ajax_approve
- admin/comments/ajax_reply

同時に、Jsonを正しく返すようにContent-typeなどを指定する機能をController::emitを改善

~(作業時間: 1h~

# note

- sigが不正だった場合に正しくリカバリーするフローが存在しない？(画面をリロードすると治るが、ユーザーには理由が通知されない）
- Javacsriptで「予期せぬ」レスポンスを受け取ったとき、エラーなどが通知されないので成功失敗がわからない（JSの改善が必要）
  - Ajax系のテストを作成する
