### PR TITLE
「月別アーカイブ」プラグイン動作不良の修正  #141

### DIFF
--- a/app/src/Model/EntriesModel.php
+++ b/app/src/Model/EntriesModel.php
@@ -126,15 +126,15 @@ class EntriesModel extends Model
     $add_where = ' AND open_status IN (' . implode(',', $open_status_list) . ')';
 
     $sql = <<<SQL
-SELECT
-  DATE_FORMAT(posted_at, '%Y') as year,
-  DATE_FORMAT(posted_at, '%m') as month,
-  COUNT(*) as count
-FROM entries
-WHERE blog_id=? {$add_where}
-GROUP BY DATE_FORMAT(posted_at, '%Y-%m')
-ORDER BY posted_at DESC
-SQL;
+      SELECT
+        DATE_FORMAT(posted_at, '%Y') as year,
+        DATE_FORMAT(posted_at, '%m') as month,
+        COUNT(*) as count
+      FROM entries
+      WHERE blog_id=? {$add_where}
+      GROUP BY year, month
+      ORDER BY concat(year, month) DESC;
+    SQL;
     $params = array($blog_id);
     $options = array('result' => DBInterface::RESULT_ALL);
     return $this->findSql($sql, $params, $options);


### PR DESCRIPTION
ref: #141 

EntriesModel::getArchives() is not compatible with mysql 5.7's default `sql_mode`.

```
which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by
```

## before

see #141

## after results

![image](https://user-images.githubusercontent.com/870716/93230376-925c8e00-f7b2-11ea-8c14-d21b1a3d8bad.png)

(作業時間 1h