### PR TITLE
Linux Docker対応やxdebug3サポート、ディレクトリ構成改善等、開発環境の改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,32 @@
+.PHONY: bash
+bash:
+	docker-compose up -d
+	docker-compose exec --user www-data php bash
+
+.PHONY: root-bash
+root-bash:
+	docker-compose up -d
+	docker-compose exec php bash
+
+.PHONY: db-drop-all-table
+db-drop-all-table:
+	docker-compose up -d
+	# e2e_testから呼び出される際のttyの都合上、ここはexecではなくrun
+	docker-compose run --rm --user www-data php bash -c "php tests/cli_drop_all_table.php"
+
+.PHONY:
+docker-compose-build-no-cache:
+	# alignment local UID/GID and docker UID/GID for Linux dev env.
+	$(eval UID := $(shell id -u))
+	$(eval GID := $(shell id -g))
+	@docker-compose build --no-cache --build-arg PUID=$(UID) --build-arg PGID=$(GID) php
+
+.PHONY:
+docker-compose-build:
+	# alignment local UID/GID and docker UID/GID for Linux dev env.
+	$(eval UID := $(shell id -u))
+	$(eval GID := $(shell id -g))
+	@docker-compose build --build-arg PUID=$(UID) --build-arg PGID=$(GID) php
 
 .PHONY: db-dump-schema
 db-dump-schema:
@@ -11,24 +40,23 @@ db-dump-all:
 db-dump-data-only:
 	mysqldump -u docker -pdocker -h 127.0.0.1 -P 3306 --complete-insert --skip-extended-insert --column-statistics=0 --skip-triggers --no-create-db --no-create-info "dev_fc2blog" | sed "s/ AUTO_INCREMENT=[0-9]*//" > dump_data.sql
 
-.PHONY: test-download-images
-test-download-images:
-	cd tests/test_images && ./download_samples.sh
-
 .PHONY: test
-test:
-	php composer.phar run test
+test: app/vendor e2e_test/node_modules tests/test_images/0.png
+	docker-compose up -d
+	make reload-test-data
+	docker-compose exec --user www-data php bash -c "php composer.phar run test"
 	cd e2e_test && npm run test
 
 .PHONY: clean
 clean:
+	docker-compose up -d
 	-rm -r app/temp/installed.lock
 	-rm -r app/temp/blog_template/*
 	-rm -r public/uploads/*
 	-rm -r tests/test_images/*.png
 	-rm -r e2e_test/node_modules/
 	-rm -r e2e_test/ss/*
-	-tests/cli_drop_all_table.php
+	-docker-compose exec --user www-data php bash -c "tests/cli_drop_all_table.php"
 	-rm -r app/vendor/
 	-rm -r node_modules/
 	-rm composer.phar
@@ -39,25 +67,32 @@ composer.phar:
 	php composer-setup.php --filename=composer.phar
 	rm composer-setup.php
 
+app/vendor: composer.phar
+	docker-compose up -d
+	docker-compose exec --user www-data php bash -c "php composer.phar install"
+
+e2e_test/node_modules:
+	cd e2e_test && npm ci
+
+tests/test_images/0.png:
+	cd tests/test_images && ./download_samples.sh
+
 .PHONY: setup-unit-test
 setup-unit-test:
 	make setup-dev
-	make setup-test-data
+	make reload-test-data
 
 .PHONY: setup-dev
-setup-dev: composer.phar
-	php composer.phar install
-	npm ci
-	cd e2e_test && npm ci
-	cd tests/test_images && ./download_samples.sh
+setup-dev: app/vendor tests/test_images/0.png
 
-.PHONY: setup-test-data
-setup-test-data:
+.PHONY: reload-test-data
+reload-test-data:
+	docker-compose up -d
 	cp -a tests/test_data/app/temp/blog_template/t app/temp/blog_template
 	cp -a tests/test_data/public/uploads/t app/temp/blog_template
 	-mkdir -p public/uploads/t/e/s/testblog2/file/
 	cp -a tests/test_images/1.png public/uploads/t/e/s/testblog2/file/1.png
 	cp -a tests/test_images/2.png public/uploads/t/e/s/testblog2/file/2.png
 	touch app/temp/installed.lock
-	tests/cli_load_fixture.php
-	tests/cli_update_template.php testblog2
+	docker-compose run --rm --user www-data php bash -c "tests/cli_load_fixture.php"
+	docker-compose run --rm --user www-data php bash -c "tests/cli_update_template.php testblog2"

--- a/README.md
+++ b/README.md
@@ -25,29 +25,29 @@ $app_dir_path = __DIR__ . "/../app";
 to
 $app_dir_path = "/path/to/your/www/app";
 ```
-　  
+
 3. Access the Installation Screen  
 [DOMAIN]/admin/common/install
-　  
+
 4. Follow the instructions and complete installation.  
-　  
+
 5. Once installation is complete, admin/install.php will no longer be necessary. Please delete it.
 
 
-#### development with Docker.
+#### test to use or development, with Docker.
 
-1. `docker-compose up` at repo root directory. wait startup.
+1. Mac: run `docker-compose up`. Linux: run `make docker-compose-build` and then `docker-compose up`.  
 2. open `http://localhost:8080/admin/common/install`
 
+* If you use Docker, you may don't need to create or edit `app/config.php`.
 * If you want to test https. open `https://localhost:8480/admin/common/install` .
-
 
 #### unit test
 
-1. `$ make setup-unit-test`
-2. `$ docker-compose start`
-3. `$ make test`
+```
+$ make test
+```
 
 * If you want to know "what's going on?", Please see the `Makefile`.  
 * Require Docker&docker-compose, PHP, node.js runtimes.
- 
+* If you got DB connection error on first run, please wait mysql initialize and retry.

--- a/app/config/init_config.php
+++ b/app/config/init_config.php
@@ -4,7 +4,7 @@ $config = [];
 
 // -------------------- ディレクトリ構造関連 --------------------//
 
-$config['ROOT_DIR'] = realpath(dirname(__FILE__) . '/../../') . '/';
+$config['ROOT_DIR'] = realpath(__DIR__ . '/../../') . '/';
 
 $config['UPLOAD_DIR_NAME'] = 'uploads';
 

--- a/app/src/Util/PhpCodeLinter.php
+++ b/app/src/Util/PhpCodeLinter.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fc2blog\Util;
+
+use PhpParser\Error;
+use PhpParser\ParserFactory;
+
+class PhpCodeLinter
+{
+  /**
+   * 文字列がPHPのコードとして正しいかLintする
+   * @param $string
+   * @return bool
+   */
+  public static function isParsablePhpCode($string)
+  {
+    $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+    try {
+      $parser->parse($string);
+    } catch (Error $error) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "ext-pdo": "*",
     "monolog/monolog": "^2.1",
     "league/flysystem": "^1.1",
-    "twig/twig": "^3.0"
+    "twig/twig": "^3.0",
+    "nikic/php-parser": "^4.10"
   },
   "config": {
     "vendor-dir": "app/vendor"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24329109caa66268559268336aaf3ddf",
+    "content-hash": "0d5b5ca27e54b241af4dc6df32730359",
     "packages": [
         {
             "name": "league/flysystem",
@@ -238,6 +238,62 @@
                 }
             ],
             "time": "2020-07-23T08:41:23+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v4.10.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
+                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
+            },
+            "time": "2020-09-26T10:30:38+00:00"
         },
         {
             "name": "psr/log",
@@ -686,58 +742,6 @@
                 }
             ],
             "time": "2020-06-29T13:22:24+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.10.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "time": "2020-09-26T10:30:38+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2460,5 +2464,5 @@
     "platform-dev": {
         "ext-pdo": "*"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,14 +40,13 @@ services:
       FC2_HTTP_PORT: "8080"
       FC2_HTTPS_PORT: "8480"
       FC2_PASSWORD_SALT: "7efe3a5b4d111b9e2148e24993c1cfdb"
-      FC2_DOCUMENT_ROOT_PATH: "/var/www/html/"
+      FC2_DOCUMENT_ROOT_PATH: "/fc2blog/public/"
       DEBUG_FORCE_CAPTCHA_KEY: "1234" # デバッグ用にCAPTCHAの値を固定する
     depends_on:
       - db
-    working_dir: "/var/www/html"
+    working_dir: "/fc2blog"
     volumes:
-      - ./public:/var/www/html
-      - ./app:/var/www/app
+      - .:/fc2blog
     ports:
       - 8080:80
       - 8480:443

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -13,6 +13,25 @@ RUN set -eux \
  && docker-php-ext-enable xdebug \
  && rm -rf /tmp/*
 
+ARG PUID=1000
+ARG PGID=1000
+
+RUN echo "-> $PUID"
+RUN echo "-> $PGID"
+
+RUN groupmod -o -g $PGID www-data && \
+    usermod -o -u $PUID -g www-data www-data && \
+    usermod --shell /bin/bash www-data
+
+COPY ./etc/apache2/sites-available/001-blog.conf /etc/apache2/sites-available/
+COPY ./usr/local/etc/php/conf.d/docker-php-ext-xdebug-debug-enable.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug-debug-enable.ini
+COPY ./usr/local/etc/php/conf.d/php-error-settings.ini /usr/local/etc/php/conf.d/php-error-settings.ini
+
+RUN make-ssl-cert generate-default-snakeoil --force-overwrite
+
 RUN a2enmod rewrite \
  && a2enmod ssl \
- && a2ensite default-ssl
+ && a2dissite default-ssl \
+ && a2dissite 000-default \
+ && a2ensite 001-blog.conf
+

--- a/docker/apache/etc/apache2/sites-available/001-blog.conf
+++ b/docker/apache/etc/apache2/sites-available/001-blog.conf
@@ -1,0 +1,28 @@
+# for development purpose.
+<VirtualHost *:80>
+    DocumentRoot /fc2blog/public
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    <Directory /fc2blog/public>
+        Options FollowSymlinks Includes
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+
+<VirtualHost _default_:443>
+    DocumentRoot /fc2blog/public
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+    SSLEngine on
+    SSLCertificateFile	/etc/ssl/certs/ssl-cert-snakeoil.pem
+    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+    <Directory /fc2blog/public>
+        Options FollowSymlinks Includes
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/docker/apache/usr/local/etc/php/conf.d/docker-php-ext-xdebug-debug-enable.ini
+++ b/docker/apache/usr/local/etc/php/conf.d/docker-php-ext-xdebug-debug-enable.ini
@@ -1,0 +1,5 @@
+xdebug.mode=debug
+xdebug.discover_client_host=On
+xdebug.var_display_max_children=-1
+xdebug.var_display_max_data=-1
+xdebug.var_display_max_depth=-1

--- a/docker/apache/usr/local/etc/php/conf.d/php-error-settings.ini
+++ b/docker/apache/usr/local/etc/php/conf.d/php-error-settings.ini
@@ -1,0 +1,4 @@
+display_errors=on
+display_startup_errors=On
+log_errors=On
+error_reporting=-1

--- a/e2e_test/package.json
+++ b/e2e_test/package.json
@@ -7,8 +7,9 @@
   "license": "MIT",
   "scripts": {
     "test": "npm run serial-test && npm run parallel-test",
-    "parallel-test": "../tests/cli_load_fixture.php && npm run clear-cache && npx jest tests/*",
-    "serial-test": "../tests/cli_drop_all_table.php && npm run clear-cache && npx jest -i 1 serial_execute_tests/*",
+    "php-prepare": "docker-compose exec --user www-data php bash -c \"php tests/cli_load_fixture.php\"",
+    "parallel-test": "npm run php-prepare && npm run clear-cache && npx jest tests/*",
+    "serial-test": "npm run php-prepare && npm run clear-cache && npx jest -i 1 serial_execute_tests/*",
     "fmt": "npx prettier --check --write \"./tests/*.ts\"",
     "clear-cache": "npx jest --clearCache",
     "test-enable-head": "NO_HEAD_LESS=1 npx jest",

--- a/e2e_test/serial_execute_tests/installer.test.ts
+++ b/e2e_test/serial_execute_tests/installer.test.ts
@@ -14,7 +14,7 @@ describe("crawl admin pages", () => {
   const nick_name = "nickname";
 
   beforeAll(async () => {
-    execSync(__dirname + "/../../tests/cli_drop_all_table.php");
+    execSync("make -C " + __dirname + "/../../ db-drop-all-table");
     if (fs.existsSync(__dirname + "/../../app/temp/installed.lock")) {
       fs.unlinkSync(__dirname + "/../../app/temp/installed.lock");
     }

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,27 +1,6 @@
-## ログ設定
-### エラーを画面に表示する、可能ならば本番時はコメントアウト推奨
-php_value display_errors on
-php_value display_startup_errors On
-### エラーをログする、本番時も有効化推奨
-php_value log_errors On
-
-## 開発時用設定、通常はコメントアウトのままとしてください。
-php_value error_reporting -1
-php_value xdebug.remote_enable On
-php_value xdebug.remote_autostart On
-php_value xdebug.remote_host host.docker.internal
-php_value xdebug.remote_port 9009
-php_value xdebug.var_display_max_children -1
-php_value xdebug.var_display_max_data -1
-php_value xdebug.var_display_max_depth -1
-
-## mod_rewirte 設定、通常修正不要
 RewriteEngine On
 RewriteBase /
-
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule . - [L]
-
 RewriteRule . index.php [L]
-

--- a/public/_for_unit_test_/.htaccess
+++ b/public/_for_unit_test_/.htaccess
@@ -1,11 +1,6 @@
-php_value display_errors on
-
 RewriteEngine On
 RewriteBase /_for_unit_test_/
-
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule . - [L]
-
 RewriteRule . index.php [L]
-

--- a/public/admin/.htaccess
+++ b/public/admin/.htaccess
@@ -1,11 +1,6 @@
-php_value display_errors on
-
 RewriteEngine On
 RewriteBase /admin/
-
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule . - [L]
-
 RewriteRule . index.php [L]
-

--- a/tests/App/Fc2Template/Fc2TemplateIfTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateIfTest.php
@@ -11,6 +11,11 @@ use ParseError;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
+/**
+ * Class Fc2TemplateIfTest
+ * FC2TemplateにおいてiF系のタグのレンダリングテスト
+ * @package Fc2blog\Tests\App\Fc2Template
+ */
 class Fc2TemplateIfTest extends TestCase
 {
   // TODO 全 fc2_template_ifをチェックできているか担保する仕組み

--- a/tests/App/Fc2Template/Fc2TemplateLoopTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateLoopTest.php
@@ -10,6 +10,11 @@ use ParseError;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
+/**
+ * Class Fc2TemplateLoopTest
+ * FC2Templateにおいてループ系のタグのレンダリングをテスト
+ * @package Fc2blog\Tests\App\Fc2Template
+ */
 class Fc2TemplateLoopTest extends TestCase
 {
   // TODO 全 fc2_template_foreachをチェックできているか担保する仕組み

--- a/tests/App/Fc2Template/Fc2TemplateTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateTest.php
@@ -25,6 +25,12 @@ use ParseError;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
+/**
+ * Class Fc2TemplateTest
+ * FC2テンプレートの各種タグ実行テスト
+ * TODO 他のテストと実質的に内容が重複している
+ * @package Fc2blog\Tests\App\Fc2Template
+ */
 class Fc2TemplateTest extends TestCase
 {
 
@@ -91,7 +97,6 @@ class Fc2TemplateTest extends TestCase
 
   /**
    * ブログトップページ（EntriesController::index）にて全タグを擬似実行
-   * NOTE: compact(array_keys(get_defined_vars())) にて、スコープ内変数が（わかりづらく）外部にて利用されているので、削除時には注意すること
    */
   public function testTagsInEntriesIndex(): void
   {

--- a/tests/LoaderHelper.php
+++ b/tests/LoaderHelper.php
@@ -29,7 +29,7 @@ class LoaderHelper extends TestCase
     putenv('FC2_SQL_DEBUG=php://stderr');
     putenv('FC2_APP_DEBUG=php://stderr');
     putenv('FC2_ERROR_ON_DISPLAY=0');
-    putenv('FC2_DB_HOST=127.0.0.1');
+    putenv('FC2_DB_HOST=db');
     putenv('FC2_DB_USER=docker');
     putenv('FC2_DB_PASSWORD=docker');
     putenv('FC2_DB_DATABASE=dev_fc2blog');

--- a/tests/LoaderHelper.php
+++ b/tests/LoaderHelper.php
@@ -14,6 +14,7 @@ class LoaderHelper extends TestCase
     # 細かなエラーを見逃さないために、Noticeを含むすべてのエラーをキャッチしてErrorExceptionに変換する
     # TODO もっとふさわしい場所に移動
     set_error_handler(function (int $severity, string $message, string $file, int $line) {
+      error_log("Error on {$file}:{$line} {$message}");
       /** @noinspection PhpUnhandledExceptionInspection */
       throw new ErrorException($message, 0, $severity, $file, $line);
     });


### PR DESCRIPTION
- 配布用zipビルド( #39 )準備のため、`.htaccess`のデバッグ用設定を削除し、php.iniへ移動
- Linux開発環境対応（Docker内のUID/GIDが不一致する不便等々）
  - CI環境(≒Linux)でテストを回す準備( #103  )
  -未検証だが、Linux対応は最終的にはWindows(+wsl+docker)開発環境対応のため
- 開発環境をシンプルにするため、phpunitなどをDockerにまとめこむ変更
- 開発用のxdebug拡張がバージョンアップで設定に互換性がなくなったのを対応
- リモートデバッグ等の為に、`fc2blog`まるごとをコンテナからマウントするように変更

（作業時間: 8h