### PR TITLE
配布用ZIPファイル生成スクリプト

### DIFF
--- a/app/src/Model/CommentsModel.php
+++ b/app/src/Model/CommentsModel.php
@@ -145,7 +145,7 @@ class CommentsModel extends Model
    * @param $comment
    * @return array
    */
-  public function editValidate($data, &$valid_data=[], $white_list, $comment)
+  public function editValidate($data, &$valid_data, $white_list, $comment)
   {
     // Validateの設定
     $this->setValidate();

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9.2",
     "ext-pdo": "*",
-    "fzaninotto/faker": "^1.9"
+    "fzaninotto/faker": "dev-master"
   },
   "autoload": {
     "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d5b5ca27e54b241af4dc6df32730359",
+    "content-hash": "0bb62d5f1eb0f3b993381d0df2ecf07c",
     "packages": [
         {
             "name": "league/flysystem",
@@ -666,26 +666,27 @@
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.9.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e"
+                "reference": "5ffe7db6c80f441f150fc88008d64e64af66634b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
-                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/5ffe7db6c80f441f150fc88008d64e64af66634b",
+                "reference": "5ffe7db6c80f441f150fc88008d64e64af66634b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "ext-intl": "*",
                 "phpunit/phpunit": "^4.8.35 || ^5.7",
                 "squizlabs/php_codesniffer": "^2.9.2"
             },
+            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -714,10 +715,10 @@
             ],
             "support": {
                 "issues": "https://github.com/fzaninotto/Faker/issues",
-                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
+                "source": "https://github.com/fzaninotto/Faker/tree/master"
             },
             "abandoned": true,
-            "time": "2020-12-11T09:56:16+00:00"
+            "time": "2020-12-11T09:59:14+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -2604,7 +2605,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "fzaninotto/faker": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -89,6 +89,10 @@
                 "sftp",
                 "storage"
             ],
+            "support": {
+                "issues": "https://github.com/thephpleague/flysystem/issues",
+                "source": "https://github.com/thephpleague/flysystem/tree/1.x"
+            },
             "funding": [
                 {
                     "url": "https://offset.earth/frankdejonge",
@@ -136,6 +140,10 @@
                 }
             ],
             "description": "Mime-type detection for Flysystem",
+            "support": {
+                "issues": "https://github.com/thephpleague/mime-type-detection/issues",
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.5.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/frankdejonge",
@@ -150,16 +158,16 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.1.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5"
+                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f9eee5cec93dfb313a38b6b288741e84e53f02d5",
-                "reference": "f9eee5cec93dfb313a38b6b288741e84e53f02d5",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
+                "reference": "1cb1cde8e8dd0f70cc0fe51354a59acad9302084",
                 "shasum": ""
             },
             "require": {
@@ -172,16 +180,17 @@
             "require-dev": {
                 "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
-                "elasticsearch/elasticsearch": "^6.0",
+                "elasticsearch/elasticsearch": "^7",
                 "graylog2/gelf-php": "^1.4.2",
+                "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4",
                 "php-console/php-console": "^3.1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.0",
                 "phpspec/prophecy": "^1.6.1",
+                "phpstan/phpstan": "^0.12.59",
                 "phpunit/phpunit": "^8.5",
                 "predis/predis": "^1.1",
                 "rollbar/rollbar": "^1.3",
-                "ruflin/elastica": ">=0.90 <3.0",
+                "ruflin/elastica": ">=0.90 <7.0.1",
                 "swiftmailer/swiftmailer": "^5.3|^6.0"
             },
             "suggest": {
@@ -201,7 +210,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -217,16 +226,20 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
+            "homepage": "https://github.com/Seldaek/monolog",
             "keywords": [
                 "log",
                 "logging",
                 "psr-3"
             ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/2.2.0"
+            },
             "funding": [
                 {
                     "url": "https://github.com/Seldaek",
@@ -237,20 +250,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-07-23T08:41:23+00:00"
+            "time": "2020-12-14T13:15:25+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.2",
+            "version": "v4.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
                 "shasum": ""
             },
             "require": {
@@ -291,9 +304,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
             },
-            "time": "2020-09-26T10:30:38+00:00"
+            "time": "2020-12-20T10:01:03+00:00"
         },
         {
             "name": "psr/log",
@@ -340,6 +353,9 @@
                 "psr",
                 "psr-3"
             ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.3"
+            },
             "time": "2020-03-23T09:12:05+00:00"
         },
         {
@@ -402,6 +418,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -479,6 +498,9 @@
                 "portable",
                 "shim"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.20.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -555,6 +577,10 @@
             "keywords": [
                 "templating"
             ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/fabpot",
@@ -571,36 +597,31 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -614,7 +635,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -623,6 +644,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -637,20 +662,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "fzaninotto/faker",
-            "version": "v1.9.1",
+            "version": "v1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fzaninotto/Faker.git",
-                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f"
+                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/fc10d778e4b84d5bd315dad194661e091d307c6f",
-                "reference": "fc10d778e4b84d5bd315dad194661e091d307c6f",
+                "url": "https://api.github.com/repos/fzaninotto/Faker/zipball/848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
+                "reference": "848d8125239d7dbf8ab25cb7f054f1a630e68c2e",
                 "shasum": ""
             },
             "require": {
@@ -687,20 +712,25 @@
                 "faker",
                 "fixtures"
             ],
-            "time": "2019-12-12T13:22:17+00:00"
+            "support": {
+                "issues": "https://github.com/fzaninotto/Faker/issues",
+                "source": "https://github.com/fzaninotto/Faker/tree/v1.9.2"
+            },
+            "abandoned": true,
+            "time": "2020-12-11T09:56:16+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -735,13 +765,17 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -797,20 +831,24 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/master"
+            },
             "time": "2020-06-27T14:33:11+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.2",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0"
+                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/c6bb6825def89e0a32220f88337f8ceaf1975fa0",
-                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/e4782611070e50613683d2b9a57730e9a3ba5451",
+                "reference": "e4782611070e50613683d2b9a57730e9a3ba5451",
                 "shasum": ""
             },
             "require": {
@@ -844,7 +882,11 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2020-06-27T14:39:04+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.0.4"
+            },
+            "time": "2020-12-13T23:18:30+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -893,6 +935,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
             "time": "2020-06-27T09:03:43+00:00"
         },
         {
@@ -945,6 +991,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+            },
             "time": "2020-09-03T19:13:55+00:00"
         },
         {
@@ -990,20 +1040,24 @@
                 }
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+            },
             "time": "2020-09-17T18:55:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.1",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
                 "shasum": ""
             },
             "require": {
@@ -1015,7 +1069,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -1053,34 +1107,38 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-09-29T09:10:42+00:00"
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
+            },
+            "time": "2020-12-19T10:15:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.2",
+            "version": "9.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "229099d7d69fe5044f6e464f669b1fd34f252e8d"
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/229099d7d69fe5044f6e464f669b1fd34f252e8d",
-                "reference": "229099d7d69fe5044f6e464f669b1fd34f252e8d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.8",
+                "nikic/php-parser": "^4.10.2",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
                 "sebastian/code-unit-reverse-lookup": "^2.0.2",
                 "sebastian/complexity": "^2.0",
                 "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0",
+                "sebastian/lines-of-code": "^1.0.3",
                 "sebastian/version": "^3.0.1",
                 "theseer/tokenizer": "^1.2.0"
             },
@@ -1120,13 +1178,17 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-28T06:24:13+00:00"
+            "time": "2020-11-28T06:44:49+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1176,6 +1238,10 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1235,6 +1301,10 @@
             "keywords": [
                 "process"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1290,6 +1360,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1345,6 +1419,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1355,16 +1433,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.4.2",
+            "version": "9.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3866b2eeeed21b1b099c4bc0b7a1690ac6fd5baa"
+                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3866b2eeeed21b1b099c4bc0b7a1690ac6fd5baa",
-                "reference": "3866b2eeeed21b1b099c4bc0b7a1690ac6fd5baa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
+                "reference": "8e16c225d57c3d6808014df6b1dd7598d0a5bbbe",
                 "shasum": ""
             },
             "require": {
@@ -1380,7 +1458,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2",
+                "phpunit/php-code-coverage": "^9.2.3",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1411,7 +1489,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.4-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
@@ -1440,6 +1518,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.0"
+            },
             "funding": [
                 {
                     "url": "https://phpunit.de/donate.html",
@@ -1450,7 +1532,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-19T09:23:29+00:00"
+            "time": "2020-12-04T05:05:53+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1496,6 +1578,10 @@
             ],
             "description": "Library for parsing CLI options",
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1548,6 +1634,10 @@
             ],
             "description": "Collection of value objects that represent the PHP code units",
             "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1599,6 +1689,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1669,6 +1763,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1722,6 +1820,10 @@
             ],
             "description": "Library for calculating the complexity of PHP code units",
             "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1784,6 +1886,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1843,6 +1949,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1916,6 +2026,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1976,6 +2090,10 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1986,16 +2104,16 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "acf76492a65401babcf5283296fa510782783a7a"
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/acf76492a65401babcf5283296fa510782783a7a",
-                "reference": "acf76492a65401babcf5283296fa510782783a7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
@@ -2029,13 +2147,17 @@
             ],
             "description": "Library for counting the lines of code in PHP source code",
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T17:03:56+00:00"
+            "time": "2020-11-28T06:42:11+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2082,6 +2204,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2133,6 +2259,10 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2192,6 +2322,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2243,6 +2377,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2295,6 +2433,10 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2344,6 +2486,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2390,6 +2536,10 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://github.com/theseer",
@@ -2445,6 +2595,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozart/assert/issues",
+                "source": "https://github.com/webmozart/assert/tree/master"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         }
     ],

--- a/dist_zip/.gitignore
+++ b/dist_zip/.gitignore
@@ -1,0 +1,3 @@
+fc2blog_dist_*
+fc2blog/
+test_vm/fc2.zip

--- a/dist_zip/Makefile
+++ b/dist_zip/Makefile
@@ -1,7 +1,8 @@
 .PHONY:
 build:
 	make clean
-	git clone -b main https://github.com/uzulla/fc2blog.git fc2blog
+	git clone --depth=1 --branch=main https://github.com/uzulla/fc2blog.git fc2blog
+	rm -rf fc2blog/.git
 	cd fc2blog && php ../../composer.phar install --no-dev --optimize-autoloader
 	cd fc2blog && zip -r ../fc2blog_dist_`git rev-parse --short HEAD`.zip app public
 

--- a/dist_zip/Makefile
+++ b/dist_zip/Makefile
@@ -1,0 +1,18 @@
+.PHONY:
+build:
+	make clean
+	git clone -b main https://github.com/uzulla/fc2blog.git fc2blog
+	cd fc2blog && php ../../composer.phar install --no-dev --optimize-autoloader
+	cd fc2blog && zip -r ../fc2blog_dist_`git rev-parse --short HEAD`.zip app public
+
+.PHONY:
+clean:
+	-rm -rf fc2blog
+	-rm fc2blog_dist_*
+	-rm test_vm/fc2.zip
+
+.PHONY:
+test:
+	make build
+	cp fc2blog_dist_`git -C fc2blog  rev-parse --short HEAD`.zip test_vm/fc2.zip
+	cd test_vm && make image-no-cache && make bash

--- a/dist_zip/README.md
+++ b/dist_zip/README.md
@@ -1,0 +1,42 @@
+# Create distribution zip
+
+Create a ZIP file for distribute.
+
+## IMPORTANT NOTICE
+
+The script will be make a zip that cloned from `https://github.com/uzulla/fc2blog` (not `fc2blog/blog`).
+
+This situation is temporary on the development. will be change to `fc2blog/blog`.
+
+## build zip
+
+```
+$ make build
+$ ls fc2blog_dist_*
+fc2blog_dist_*****.zip
+```
+
+`fc2blog_dist_*****.zip` is distributable zip. (***** is short commit id)
+
+that contain `app`, `public`, and `app/vendor/`(libraries that installed by the composer).
+
+## test on Ubuntu vm(docker)
+
+```
+$ make test
+{some logs output}
+If you want exit. please exit or ctrl-D
+==================================
+http://172.17.0.2/admin/common/install
+==================================
+{some logs output}
+root@2792c09097ef:/# exit
+```
+
+> All data is not permanent. All data will be lost when exited.
+
+## clean
+
+```
+$ make clean
+```

--- a/dist_zip/test_vm/001-blog.conf
+++ b/dist_zip/test_vm/001-blog.conf
@@ -1,0 +1,28 @@
+# for development purpose.
+<VirtualHost *:80>
+    DocumentRoot /var/www/html
+    ErrorLog /dev/stdout
+    CustomLog /dev/stdout combined
+
+    <Directory /var/www/html>
+        Options FollowSymlinks Includes
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+
+<VirtualHost _default_:443>
+    DocumentRoot /var/www/html
+    ErrorLog /dev/stdout
+    CustomLog /dev/stdout combined
+
+    SSLEngine on
+    SSLCertificateFile	/etc/ssl/certs/ssl-cert-snakeoil.pem
+    SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+    <Directory /var/www/html>
+        Options FollowSymlinks Includes
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>

--- a/dist_zip/test_vm/Dockerfile
+++ b/dist_zip/test_vm/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux \
 RUN add-apt-repository -y ppa:ondrej/php \
  && add-apt-repository -y ppa:ondrej/apache2 \
  && apt-get update \
- && apt-get install -y apache2 mysql-server php8.0 libapache2-mod-php8.0 php-mysql php8.0-intl php8.0-mbstring php8.0-gd php8.0-mysql
+ && apt-get install -y apache2 mysql-server php8.0 libapache2-mod-php8.0 php8.0-intl php8.0-mbstring php8.0-gd php8.0-mysql
 
 ARG PUID=1000
 ARG PGID=1000
@@ -36,7 +36,7 @@ RUN mkdir /var/run/mysqld \
 
 # XXX
 RUN sh -c "/usr/bin/mysqld_safe --user=mysql &" \
- && sleep 5 \
+ && sleep 3 \
  && mysql_secure_installation -ppass -D \
  && echo "CREATE DATABASE fc2" | mysql \
  && echo "CREATE USER 'dbuser'@'127.0.0.1' IDENTIFIED BY 'd1B2p3a#s!s';" | mysql \

--- a/dist_zip/test_vm/Dockerfile
+++ b/dist_zip/test_vm/Dockerfile
@@ -1,0 +1,56 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux \
+ && apt-get update -y \
+ && apt-get upgrade -y \
+ && apt-get install -y software-properties-common iproute2 vim git wget unzip locales ssl-cert \
+ && sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen \
+ && locale-gen \
+ && rm -rf /tmp/*
+
+RUN add-apt-repository -y ppa:ondrej/php \
+ && add-apt-repository -y ppa:ondrej/apache2 \
+ && apt-get update \
+ && apt-get install -y apache2 mysql-server php8.0 libapache2-mod-php8.0 php-mysql php8.0-intl php8.0-mbstring php8.0-gd php8.0-mysql
+
+ARG PUID=1000
+ARG PGID=1000
+
+RUN groupmod -o -g $PGID www-data && \
+    usermod -o -u $PUID -g www-data www-data && \
+    usermod --shell /bin/bash www-data
+
+COPY 001-blog.conf /etc/apache2/sites-available/
+
+RUN make-ssl-cert generate-default-snakeoil --force-overwrite \
+ && a2enmod rewrite \
+ && a2enmod ssl \
+ && a2ensite 001-blog \
+ && a2dissite 000-default.conf \
+ && a2dissite default-ssl.conf
+
+RUN mkdir /var/run/mysqld \
+ && chmod 777 /var/run/mysqld
+
+# XXX
+RUN sh -c "/usr/bin/mysqld_safe --user=mysql &" \
+ && sleep 5 \
+ && mysql_secure_installation -ppass -D \
+ && echo "CREATE DATABASE fc2" | mysql \
+ && echo "CREATE USER 'dbuser'@'127.0.0.1' IDENTIFIED BY 'd1B2p3a#s!s';" | mysql \
+ && echo "GRANT ALL ON fc2.* TO 'dbuser'@'127.0.0.1';" | mysql
+
+COPY fc2.zip /tmp
+RUN cd tmp \
+ && unzip fc2.zip \
+ && mv app /var/www/ \
+ && mv public/* /var/www/html/ \
+ && mv public/.htaccess /var/www/html/ \
+ && chown -R www-data:www-data /var/www/ \
+ && rm /var/www/html/index.html
+
+COPY config.php /var/www/app/
+
+COPY startup.sh /

--- a/dist_zip/test_vm/Makefile
+++ b/dist_zip/test_vm/Makefile
@@ -1,0 +1,22 @@
+PHONY:
+image:
+	# alignment local UID/GID and docker UID/GID for Linux dev env.
+	$(eval UID := $(shell id -u))
+	$(eval GID := $(shell id -g))
+	docker build -t fc2_dist_test_vm --build-arg PUID=$(UID) --build-arg PGID=$(GID) .
+
+PHONY:
+image-no-cache:
+	# alignment local UID/GID and docker UID/GID for Linux dev env.
+	$(eval UID := $(shell id -u))
+	$(eval GID := $(shell id -g))
+	docker build -t fc2_dist_test_vm --no-cache --build-arg PUID=$(UID) --build-arg PGID=$(GID) .
+
+PHONY:
+run:
+	docker run --rm -it fc2_dist_test_vm sh -c "/startup.sh ; bash"
+
+PHONY:
+bash:
+	docker run --rm -it fc2_dist_test_vm bash
+

--- a/dist_zip/test_vm/config.php
+++ b/dist_zip/test_vm/config.php
@@ -1,0 +1,20 @@
+<?php
+error_reporting(-1);
+
+// DBの接続情報
+define('DB_HOST', '127.0.0.1'); // dbのホスト名
+define('DB_USER', 'dbuser'); // dbのユーザー名
+define('DB_PASSWORD', 'd1B2p3a#s!s'); // dbのパスワード
+define('DB_DATABASE', 'fc2'); // dbのデータベース名
+define('DB_CHARSET', 'UTF8MB4'); // MySQL 5.5未満の場合はUTF8を指定してください
+
+// サーバーの設定情報
+define('DOMAIN', 'example.test'); // ドメイン名
+define('HTTP_PORT', '80'); // HTTP時ポート
+define('HTTPS_PORT', '443'); // HTTPS時ポート
+
+define('PASSWORD_SALT', 'BgbXeZJQy9ijBNThVZ0zU6wbiXmerjpJ');
+
+define('WWW_DIR', __DIR__ . '/../html/');
+
+require(__DIR__ . '/core/bootstrap.php');

--- a/dist_zip/test_vm/startup.sh
+++ b/dist_zip/test_vm/startup.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env sh
+
+/usr/bin/mysqld_safe --user=mysql &
+
+APACHE_RUN_DIR=/var/run/apache2 \
+APACHE_PID_FILE=/var/run/apache2/pid \
+APACHE_RUN_USER=www-data \
+APACHE_RUN_GROUP=www-data \
+APACHE_LOG_DIR=/var/log/apache2/ \
+APACHE_CONFDIR=/etc/apache2 \
+/usr/sbin/apache2  -DFOREGROUND &
+
+sleep 3
+echo "If you want exit. please exit or ctrl-D"
+
+echo ==================================
+echo "http://`ip -4 addr | grep -oP '(?<=inet\s)\d+(\.\d+){3}' |grep -v 127.0.0.1`/admin/common/install"
+echo ==================================
+

--- a/docker/apache/Dockerfile
+++ b/docker/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.0-apache
 
 RUN set -eux \
  && apt-get update -y \

--- a/docker/mysqld/Dockerfile
+++ b/docker/mysqld/Dockerfile
@@ -1,3 +1,13 @@
 FROM mysql:5.7
 
+ARG PUID=1000
+ARG PGID=1000
+
+RUN echo "-> $PUID"
+RUN echo "-> $PGID"
+
+RUN groupmod -o -g $PGID mysql && \
+    usermod -o -u $PUID -g mysql mysql && \
+    usermod --shell /bin/bash mysql
+
 COPY mysqld.cnf /etc/mysql/mysql.conf.d/mysqld.cnf

--- a/docker/mysqld/Dockerfile
+++ b/docker/mysqld/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5.7
+FROM mysql:8.0
 
 ARG PUID=1000
 ARG PGID=1000

--- a/tests/App/Lib/CaptchaImage/DrawNumberTest.php
+++ b/tests/App/Lib/CaptchaImage/DrawNumberTest.php
@@ -6,6 +6,7 @@ namespace Fc2blog\Tests\App\Lib\CaptchaImage;
 
 use Exception;
 use Fc2blog\Lib\CaptchaImage;
+use GdImage;
 use PHPUnit\Framework\TestCase;
 
 class DrawNumberTest extends TestCase
@@ -74,7 +75,7 @@ class DrawNumberTest extends TestCase
   {
     $params = $this->getDefaultParams();
     $gif_resource = $this->generateGifImage($params);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
   }
 
   public function testDrawEnNumber(): void
@@ -82,7 +83,7 @@ class DrawNumberTest extends TestCase
     $params = $this->getDefaultParams();
     $params['isJa'] = false;
     $gif_resource = $this->generateGifImage($params);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
   }
 
   public function testDrawOddSize(): void
@@ -91,7 +92,7 @@ class DrawNumberTest extends TestCase
     $params['size_x'] = 199;
     $params['size_y'] = 39;
     $gif_resource = $this->generateGifImage($params);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
   }
 
   public function testDrawToSmall(): void
@@ -101,18 +102,18 @@ class DrawNumberTest extends TestCase
     $params['size_x'] = 8;
     $params['size_y'] = 1;
     $gif_resource = $this->generateGifImage($params);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
     $gif_resource = $this->generateGifImage($params, false);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
   }
 
   public function testMiniOrNotMiniMode(): void
   {
     $params = $this->getDefaultParams();
     $gif_resource = $this->generateGifImage($params, true);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
     $gif_resource = $this->generateGifImage($params, false);
-    $this->assertIsResource($gif_resource);
+    $this->assertInstanceOf(GdImage::class, $gif_resource);
   }
 
 }


### PR DESCRIPTION
(#192を先にマージしてください

rel: #39 

- ウェブアプリ動作に必要な`app`, `public`, `app/vendor`(composerにより生成)をZIPにまとめたものを生成するスクリプト
- zipの動作検証用のdocker(ubuntuベース)環境
- READMEやLICENSEファイルのコピーなど、zipファイルの拡充は追って行います #204

(作業時間 6h)

## note

現状はレビューなどのために`fc2blog/blog`のmasterへのマージにかなり期間がかかるため、一時的にzipは `uzulla/fc2blog` repoの`main` branchより生成しています。
支障がなくなれば`fc2blog/blog`に切り替えます。