### PR TITLE
デフォルトブログ機能の追加

### DIFF
--- a/app/config/init_config.php
+++ b/app/config/init_config.php
@@ -358,4 +358,12 @@ $config['PAGE'] = array(
   ),
 );
 
+$config['DEFAULT_BLOG_ID'] = defined("DEFAULT_BLOG_ID") ? DEFAULT_BLOG_ID : null;
+if (
+  defined("THIS_IS_TEST") ||
+  preg_match("/THIS_IS_TEST/u", $_SERVER['HTTP_USER_AGENT'])
+) {// TODO シングルテナントモードのテスト系が出来てからはずす
+  $config['DEFAULT_BLOG_ID'] = null;
+}
+
 return $config;

--- a/app/config/init_config.php
+++ b/app/config/init_config.php
@@ -359,10 +359,9 @@ $config['PAGE'] = array(
 );
 
 $config['DEFAULT_BLOG_ID'] = defined("DEFAULT_BLOG_ID") ? DEFAULT_BLOG_ID : null;
-if (
-  defined("THIS_IS_TEST") ||
-  preg_match("/THIS_IS_TEST/u", $_SERVER['HTTP_USER_AGENT'])
-) {// TODO シングルテナントモードのテスト系が出来てからはずす
+// TODO E2E testでシングルテナントモード対応ができたら外す
+// UserAgentでDefault Blog Id設定を強制オフにする
+if (isset($_SERVER['HTTP_USER_AGENT']) && preg_match("/THIS_IS_TEST/u", $_SERVER['HTTP_USER_AGENT'])) {
   $config['DEFAULT_BLOG_ID'] = null;
 }
 

--- a/app/config_read_from_env.php
+++ b/app/config_read_from_env.php
@@ -40,5 +40,8 @@ define('HTTPS_PORT', (string)getenv("FC2_HTTPS_PORT")); // ex: 443, 8480
 // Please edit the path when change `app` and `public` relative path condition.
 define('WWW_DIR', (string)getenv("FC2_DOCUMENT_ROOT_PATH"));
 
+//define('DEFAULT_BLOG_ID', (string)getenv("DEFAULT_BLOG_ID"));
+define("DEFAULT_BLOG_ID", (string)getenv("FC2_DEFAULT_BLOG_ID"));
+
 // 設定クラス読み込み
 require(__DIR__ . '/core/bootstrap.php');

--- a/app/src/App.php
+++ b/app/src/App.php
@@ -363,7 +363,7 @@ class App
       if (count($params)) {
         $url .= '?' . implode('&', $params);
       }
-      if ($blog_id) {
+      if ($blog_id && $blog_id !== Config::get('DEFAULT_BLOG_ID')) {
         $url = '/' . $blog_id . $url;
       }
       $url = ($abs ? $full_domain : '') . $url;
@@ -385,7 +385,7 @@ class App
       if (count($params) > 0) {
         $url .= '?' . implode('&', $params);
       }
-      if ($blog_id) {
+      if ($blog_id && $blog_id !== Config::get('DEFAULT_BLOG_ID')) {
         $url = '/' . $blog_id . $url;
       }
       $url = ($abs ? $full_domain : '') . $url;
@@ -406,7 +406,7 @@ class App
     if (count($params)) {
       $url .= '?' . implode('&', $params);
     }
-    if ($blog_id) {
+    if ($blog_id && $blog_id !== Config::get('DEFAULT_BLOG_ID')) {
       $url = '/' . $blog_id . $url;
     }
     $url = ($abs ? $full_domain : '') . $url;

--- a/app/src/Model/BlogsModel.php
+++ b/app/src/Model/BlogsModel.php
@@ -727,4 +727,33 @@ class BlogsModel extends Model
 
     return $blog_array['redirect_status_code'];
   }
+
+  /**
+   * @return string|null
+   */
+  static public function getDefaultBlogId(): ?string
+  {
+    if (strlen(Config::get("DEFAULT_BLOG_ID", ""))>0) {
+      return Config::get("DEFAULT_BLOG_ID");
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * @param Request $request
+   * @return string|null
+   */
+  static public function getBlogIdByRequestOrDefault(Request $request): ?string
+  {
+    if($request->getBlogId()){
+      return $request->getBlogId();
+
+    } else if (Config::get("DEFAULT_BLOG_ID", "") && !is_null(BlogsModel::getDefaultBlogId())) {
+      return BlogsModel::getDefaultBlogId();
+
+    } else {
+      return null;
+    }
+  }
 }

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -346,8 +346,13 @@ abstract class Controller
     }
 
     // FC2用のどこでも有効な単変数
-    $data['url'] = '/' . $data['blog']['id'] . '/';
     $data['blog_id'] = UserController::getBlogId($request); // TODO User系でしかこのメソッドは呼ばれないはずなので
+    if ($data['blog_id'] !== Config::get('DEFAULT_BLOG_ID')) {
+      $data['url'] = '/' . $data['blog']['id'] . '/';
+    } else {
+      // シングルテナントモード、DEFAULT_BLOG_IDとBlogIdが一致するなら、Pathを省略する
+      $data['url'] = '/';
+    }
 
     // 年月日系
     $data['now_date'] = (isset($data['date_area']) && $data['date_area']) ? $data['now_date'] : date('Y-m-d');

--- a/app/src/Web/Controller/User/UserController.php
+++ b/app/src/Web/Controller/User/UserController.php
@@ -17,7 +17,7 @@ abstract class UserController extends AppController
    */
   public static function getBlogId(Request $request): ?string
   {
-    return $request->get('blog_id');
+    return $request->getBlogId();
   }
 
   /**

--- a/app/src/Web/Html.php
+++ b/app/src/Web/Html.php
@@ -88,7 +88,15 @@ class Html
     if (count($params)) {
       $url .= '?' . implode('&', $params);
     }
-    if ($blog_id) {
+    // シングルテナントモードのために、/testblog2/〜〜 のブログ指定部分を省略するか？を決定
+    if (
+      $blog_id && (
+        // Default Blog IDが未指定か
+        strlen(Config::get('DEFAULT_BLOG_ID'))===0 ||
+        // 指定されたblog_idがDefault blog idと異なる場合
+        $blog_id !== Config::get('DEFAULT_BLOG_ID')
+      )
+    ) {
       $url = '/' . $blog_id . $url;
     }
 

--- a/app/src/Web/Request.php
+++ b/app/src/Web/Request.php
@@ -421,9 +421,15 @@ class Request
   {
     $paths = $this->getPaths();
 
-    // blog_id「かもしれないもの」を取得する
+    if(isset($this->request['blog_id'])){
+      // すでに解決されているので再利用
+      return $this->request['blog_id'];
+    }
+
+    // URLのblog_id「かもしれないもの」を取得し、保存する
     if (isset($paths[0]) && preg_match('|\A[0-9a-zA-Z]+\z|u', $paths[0])) {
-      return $paths[0];
+      $this->set('blog_id', $paths[0]);
+      return $this->request['blog_id'];
     } else {
       return null;
     }

--- a/app/src/Web/Router/Router.php
+++ b/app/src/Web/Router/Router.php
@@ -69,22 +69,29 @@ class Router
       $args_controller = "mode";
       $args_action = "process";
 
-      if ($request->get($args_controller) == "common") {
+      if ($request->get($args_controller) === "common") {
         $this->className = CommonController::class;
       }
 
       // blog_idの設定
       if (isset($paths[0]) && preg_match('|\A[0-9a-zA-Z]+\z|u', $paths[0])) {
-        $this->className = EntriesController::class;
+        $this->className = EntriesController::class; // TODO delete
         $request->set('blog_id', $paths[0]);
+        $blog_id = $paths[0];
       }
 
-      if ($request->isArgs('xml')) { // `/?xml`
+      // `/`の場合
+      if($path === "/"){
+        $this->className = BlogsController::class;
+        $this->methodName = 'index';
+      }
+
+      if (isset($blog_id) && $request->isArgs('xml')) { // `/?xml`
         // RSS feed
         $this->className = BlogsController::class;
         $this->methodName = 'feed';
 
-      } else if (isset($paths[0]) && !$request->isArgs($args_action)) {
+      } else if (isset($blog_id) && !$request->isArgs($args_action)) {
         // トップページ
         $this->methodName = 'index';
 

--- a/app/src/Web/Router/Router.php
+++ b/app/src/Web/Router/Router.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * リクエストクラス
- * POST,GETへのアクセスを便利にするクラス
- */
-
 namespace Fc2blog\Web\Router;
 
 use Fc2blog\Util\StringCaseConverter;

--- a/app/src/Web/Router/Router.php
+++ b/app/src/Web/Router/Router.php
@@ -38,6 +38,7 @@ class Router
     $args_action = "process";
 
     if (preg_match('|\A/admin/|u', $request->uri)) { // Admin routing
+      // http://example.jp/admin/* が対応
       $request->urlRewrite = true;
       $request->baseDirectory = '/admin/';
       $this->className = \Fc2blog\Web\Controller\Admin\CommonController::class; // default controller.
@@ -84,6 +85,7 @@ class Router
       }
 
       if (isset($blog_id) && $request->isArgs('xml')) { // `/?xml`
+        // http://example.jp/blogid/*?xml が対応
         // RSS feed
         $this->className = BlogsController::class;
         $this->methodName = 'feed';
@@ -118,77 +120,92 @@ class Router
         $this->className = EntriesController::class;
 
         if (isset($sub_path) && strpos($sub_path, 'archives.html') === 0) {
+          // http://example.jp(/blogid)?/archives.html が対応
           // アーカイブ
           $this->methodName = 'archive';
 
         } else if ($request->rawHasGet('no') && $request->isGet()) {
+          // http://example.jp(/blogid)?/*?no=XX が対応
           // 記事詳細
           $this->methodName = 'view';
           $request->set('id', $request->get('no'));
 
         } else if ($request->isArgs('no') && $request->isArgs('m2')) {
+          // http://example.jp(/blogid)?/*?m2=XX&no=XX が対応
           // モバイル用 記事詳細（フォーム表示など
           $this->methodName = 'view';
           $request->set('id', $request->get('no'));
 
         } else if (isset($sub_path) && preg_match('/^blog-entry-([0-9]+)\.html$/u', $sub_path, $matches)) {
+          // http://example.jp(/blogid)?/blog-entry-123.html(.*) が対応
           // 記事詳細
           $this->methodName = 'view';
           $request->set('id', $matches[1]);
 
         } else if ($request->rawHasGet('mp')) {
+          // http://example.jp(/blogid)?/*?mp=XX が対応
           // プラグイン単体
           $this->methodName = 'plugin';
           $request->set('id', $request->get('mp'));
 
         } else if ($request->rawHasGet('tag')) {
+          // http://example.jp(/blogid)?/*?tag=XX が対応
           // タグ
           $this->methodName = 'tag';
 
         } else if ($request->rawHasGet('cat')) {
+          // http://example.jp(/blogid)?/*?cat=XX が対応
           // カテゴリー
           $this->methodName = 'category';
 
         } else if ($request->rawHasGet('q')) {
+          // http://example.jp(/blogid)?/*?q=XX が対応
           // 検索
           $this->methodName = 'search';
 
         } else {
+          // ここまでの条件にかからないものが対応
           // トップページ
           $this->methodName = 'index';
 
         }
 
       } else if ($request->get($args_controller) === "common" && $request->get($args_action) === "captcha") {
+        // http://example.jp/(index.php)?mode=common&process=captcha が対応
         // captcha画像生成
         $this->className = CommonController::class;
         $this->methodName = 'captcha';
 
       } else if ($request->get($args_controller) === "common" && $request->get($args_action) === "device_change") {
+        // http://example.jp/(index.php)?mode=common&process=device_change が対応
         // 機種切り替え、つかわれているケースがあるか不明
         $this->className = CommonController::class;
         $this->methodName = 'device_change';
 
       } else if ($request->get($args_controller) === "common" && $request->get($args_action) === "lang") {
+        // http://example.jp/(index.php)?mode=common&process=lang が対応
         // 言語切り替え
         $this->className = CommonController::class;
         $this->methodName = 'lang';
 
       } else if ($request->get($args_controller) === "blogs" && $request->get($args_action) === "index") {
+        // http://example.jp/(index.php)?mode=blogs&process=index が対応
         $this->className = BlogsController::class;
         $this->methodName = 'index';
 
       } else if (!isset($blog_id)) {
-        // blog_idが存在しない場合
+        // ここまでかからず、なおかつblog_idが判定できなかった場合
         $this->className = BlogsController::class;
         $this->methodName = 'index';
 
       } else if ($this->className === "") {
         // Class(mode)がargsで指定がなく、ここまでに確定しなければEntriesController
+        // このrouteに明記はないが、EntriesController::* を指定するルートが存在する
         $this->className = EntriesController::class;
       }
 
-      // ここまでmethodが不定の場合、processから決定
+      // ここまでかからずmethodが不定の場合、process引数から決定
+      // このrouteに明記はないが、EntriesController::* を指定するルートが存在する
       if ($this->methodName === "") {
         $this->methodName = $request->get($args_action);
       }

--- a/app/src/Web/Router/Router.php
+++ b/app/src/Web/Router/Router.php
@@ -6,7 +6,6 @@
 
 namespace Fc2blog\Web\Router;
 
-use Fc2blog\Config;
 use Fc2blog\Util\StringCaseConverter;
 use Fc2blog\Web\Controller\Admin\AdminController;
 use Fc2blog\Web\Controller\User\BlogsController;
@@ -24,7 +23,7 @@ class Router
   public function __construct(Request $request)
   {
     $this->request = $request;
-    // TODO if文ベースのルーターから、なんらかのルーターに切り替えたい（Config全廃が前提）
+    // TODO if文ベースのルーターから、なんらかのルーターに切り替えたい
 
     // favicon.ico アクセス時に404をレスポンスし、ブラウザにリトライさせない。
     // しない場合、404扱いからのブログページへリダイレクトが発生し、無駄な資源を消費する。
@@ -35,16 +34,17 @@ class Router
       return;
     }
 
+    // ユーザー用のパラメータを設定する
+    $path = $request->getPath();
+    $paths = $request->getPaths();
+    $args_controller = "mode";
+    $args_action = "process";
+
     if (preg_match('|\A/admin/|u', $request->uri)) { // Admin routing
       $request->urlRewrite = true;
       $request->baseDirectory = '/admin/';
       $this->className = \Fc2blog\Web\Controller\Admin\CommonController::class; // default controller.
       $this->methodName = 'index'; // default method.
-
-      // 管理用のパラメータを設定する
-      $paths = $request->getPaths();
-      $args_controller = Config::get('ARGS_CONTROLLER');
-      $args_action = Config::get('ARGS_ACTION');
 
       if ($request->isArgs($args_controller)) {
         $this->className = "Fc2blog\\Web\\Controller\\Admin\\" . StringCaseConverter::pascalCase($request->get($args_controller)) . "Controller";
@@ -61,30 +61,32 @@ class Router
     } else { // User Routing
       $request->urlRewrite = false;
       $request->baseDirectory = '/';
-      $this->className = BlogsController::class; // default controller.
 
-      // ユーザー用のパラメータを設定する
-      $path = $request->getPath();
-      $paths = $request->getPaths();
-      $args_controller = "mode";
-      $args_action = "process";
+      $default_blog_id = "testblog2";// TODO なんらか設定から引くように
+      $default_blog_id = null;
 
-      if ($request->get($args_controller) === "common") {
-        $this->className = CommonController::class;
-      }
+      // 対象となるblogを決定する
+      if ($path === "/" && !is_null($default_blog_id)) {
+        // `/`であり(blog_idがURLに無く)、デフォルトblog_idが存在する場合、デフォルトblog_idのトップを表示する
+        $blog_id = $default_blog_id;
+        $request->set('blog_id', $blog_id);
+        if (isset($paths[0])) {
+          $sub_path = $paths[0];
+        }
 
-      // blog_idの設定
-      if (isset($paths[0]) && preg_match('|\A[0-9a-zA-Z]+\z|u', $paths[0])) {
-        $this->className = EntriesController::class; // TODO delete
-        $request->set('blog_id', $paths[0]);
-        $blog_id = $paths[0];
-      }
-
-      // `/`の場合
-      if($path === "/"){
+      } else if ($path === "/" && is_null($default_blog_id)) {
+        // `/`であり(blog_idがURLに無く)、デフォルトblog_idが存在しない場合
         $this->className = BlogsController::class;
         $this->methodName = 'index';
+
+      } else if (!is_null($request->getBlogId())) {
+        // blog_idがURLから特定できる場合
+        $blog_id = $request->getBlogId();
+        if (isset($paths[1])) {
+          $sub_path = $paths[1];
+        }
       }
+      // TODO: blog_idがURLから特定できない場合でsub_pathを規定しないといけない？
 
       if (isset($blog_id) && $request->isArgs('xml')) { // `/?xml`
         // RSS feed
@@ -92,23 +94,23 @@ class Router
         $this->methodName = 'feed';
 
       } else if (isset($blog_id) && !$request->isArgs($args_action)) {
-        // トップページ
-        $this->methodName = 'index';
+        $this->className = EntriesController::class;
 
-        if ($request->rawHasGet('no') && $request->isGet()) {
+        if (isset($sub_path) && strpos($sub_path, 'archives.html') === 0) {
+          // アーカイブ
+          $this->methodName = 'archive';
+
+        } else if ($request->rawHasGet('no') && $request->isGet()) {
           // 記事詳細
           $this->methodName = 'view';
           $request->set('id', $request->get('no'));
 
         } else if ($request->isArgs('no') && $request->isArgs('m2')) {
+          // モバイル用 記事詳細（フォーム表示など
           $this->methodName = 'view';
           $request->set('id', $request->get('no'));
 
-        } else if (isset($paths[1]) && strpos($paths[1], 'archives.html') === 0) {
-          // アーカイブ
-          $this->methodName = 'archive';
-
-        } else if (isset($paths[1]) && preg_match('/^blog-entry-([0-9]+)\.html$/u', $paths[1], $matches)) {
+        } else if (isset($sub_path) && preg_match('/^blog-entry-([0-9]+)\.html$/u', $sub_path, $matches)) {
           // 記事詳細
           $this->methodName = 'view';
           $request->set('id', $matches[1]);
@@ -129,6 +131,10 @@ class Router
         } else if ($request->rawHasGet('q')) {
           // 検索
           $this->methodName = 'search';
+
+        } else {
+          // トップページ
+          $this->methodName = 'index';
         }
 
       } else if (preg_match('{/uploads/[0-9a-zA-Z]/[0-9a-zA-Z]/[0-9a-zA-Z]/([0-9a-zA-Z]+)/file/([0-9]+)_([wh]?)([0-9]+)\.(png|gif|jpe?g)$}', $path, $matches)) {
@@ -152,8 +158,33 @@ class Router
         $request->set('height', $matches[5]);
         $request->set('ext', $matches[6]);
 
-      }else if ($this->methodName === "") {
-        // 一つもかからなかった
+      } else if ($request->get($args_controller) === "common" && $request->get($args_action) === "captcha") {
+        // captcha画像生成
+        $this->className = CommonController::class;
+        $this->methodName = 'captcha';
+
+      } else if ($request->get($args_controller) === "common" && $request->get($args_action) === "device_change") {
+        // 機種切り替え、つかわれているケースがあるか不明
+        $this->className = CommonController::class;
+        $this->methodName = 'device_change';
+
+      } else if ($request->get($args_controller) === "common" && $request->get($args_action) === "lang") {
+        // 言語切り替え
+        $this->className = CommonController::class;
+        $this->methodName = 'lang';
+
+      } else if ($request->get($args_controller) === "blogs" && $request->get($args_action) === "index") {
+        // 言語切り替え
+        $this->className = BlogsController::class;
+        $this->methodName = 'index';
+
+      } else if ($this->className === "") {
+        // Class(mode)がargsで指定がなく、ここまでに確定しなければEntriesController
+        $this->className = EntriesController::class;
+      }
+
+      // ここまでmethodが不定の場合、processから決定
+      if ($this->methodName === "") {
         $this->methodName = $request->get($args_action);
       }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       FC2_HTTPS_PORT: "8480"
       FC2_DOCUMENT_ROOT_PATH: "/fc2blog/public/"
       DEBUG_FORCE_CAPTCHA_KEY: "1234" # デバッグ用にCAPTCHAの値を固定する
+      # FC2_DEFAULT_BLOG_ID: "testblog2" # experimental single tenant mode.
     depends_on:
       - db
     working_dir: "/fc2blog"

--- a/e2e_test/tests/helper.ts
+++ b/e2e_test/tests/helper.ts
@@ -20,7 +20,7 @@ export class Helper {
   async init(): Promise<void> {
     this.requestHttpHeaders = {
       'Accept-Language': 'ja,en-US;q=0.9,en;q=0.8',
-      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36'
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36 THIS_IS_TEST'
     };
     this.browser = await puppeteer.launch({
       args: ['--lang=ja'],
@@ -42,7 +42,7 @@ export class Helper {
 
   async setSpUserAgent(): Promise<void> {
     let spRequestHttpHeaders = this.requestHttpHeaders;
-    spRequestHttpHeaders['User-Agent'] = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Mobile Safari/537.36';
+    spRequestHttpHeaders['User-Agent'] = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Mobile Safari/537.36 THIS_IS_TEST';
     await this.page.setExtraHTTPHeaders(spRequestHttpHeaders);
     await this.page.setViewport({
       width: 400,

--- a/tests/App/DefaultBlogIdMode/UrlTest.php
+++ b/tests/App/DefaultBlogIdMode/UrlTest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Fc2blog\Tests\App\DefaultBlogIdMode;
+
+use Fc2blog\Config;
+use Fc2blog\Tests\Helper\ClientTrait;
+use PHPUnit\Framework\TestCase;
+
+// Configを直接操作するテストをおこなうため、この内部でFailすると他テストに影響する可能性あり
+class UrlTest extends TestCase
+{
+  use ClientTrait;
+
+  public function testHeaderLinkUrlWithOutDefaultBlogId(): void
+  {
+    // no default blog
+    Config::set('DEFAULT_BLOG_ID', null);
+    $c = $this->reqGet('/testblog2/');
+    $this->assertStringContainsString('<h1><a href="/testblog2/"', $c->getOutput());
+    Config::set('DEFAULT_BLOG_ID', null);
+  }
+
+  public function testHeaderLinkUrlWithDefaultBlogId(): void
+  {
+    // set default blog to "testblog2"
+    Config::set('DEFAULT_BLOG_ID', 'testblog2');
+    $c = $this->reqGet('/testblog2/');
+    $this->assertStringNotContainsString('<h1><a href="/testblog2/', $c->getOutput());
+    $this->assertStringContainsString('<h1><a href="/"', $c->getOutput());
+    Config::set('DEFAULT_BLOG_ID', null);
+  }
+}

--- a/tests/App/DefaultBlogIdMode/UrlTest.php
+++ b/tests/App/DefaultBlogIdMode/UrlTest.php
@@ -42,10 +42,32 @@ class UrlTest extends TestCase
 
   public function testHeaderLinkUrlNotDefaultBlogWithOutDefaultBlogId(): void
   {
-    // set default blog to "testblog2"
     Config::set('DEFAULT_BLOG_ID', null);
     $c = $this->reqHttpsGet('/testblog1/');
     $this->assertStringContainsString('<h1><a href="/testblog1/"', $c->getOutput());
+    Config::set('DEFAULT_BLOG_ID', null);
+  }
+
+  public function testEntryLinkUrl(): void
+  {
+    // Default blog なしのときのエントリリンク先にblog idが含まれていること
+    Config::set('DEFAULT_BLOG_ID', null);
+    $d = static::getFc2PreprocessedData("GET", "/testblog2/");
+//    var_dump($d);
+    $this->assertEquals('testblog2', $d['blog_id']);
+    // HTML::urlのテストのため
+    $this->assertEquals('/testblog2/blog-entry-3.html', $d['entries'][0]['link']);
+    $this->assertStringContainsString("/testblog2/", $d['_calender_data'][3][5]);// テストデータに依存しているので、壊れやすい
+
+    // Default blog ありの時のエントリリンク先にblog idが含まれていないこと
+    Config::set('DEFAULT_BLOG_ID', 'testblog2');
+    $d = static::getFc2PreprocessedData("GET", "/testblog2/");
+//    var_dump($d);
+    $this->assertEquals('testblog2', $d['blog_id']);
+    $this->assertEquals('/blog-entry-3.html', $d['entries'][0]['link']);
+    $this->assertStringNotContainsString("/testblog2/", $d['_calender_data'][3][5]);// テストデータに依存しているので、壊れやすい
+
+    // 掃除
     Config::set('DEFAULT_BLOG_ID', null);
   }
 }

--- a/tests/App/DefaultBlogIdMode/UrlTest.php
+++ b/tests/App/DefaultBlogIdMode/UrlTest.php
@@ -26,8 +26,26 @@ class UrlTest extends TestCase
     // set default blog to "testblog2"
     Config::set('DEFAULT_BLOG_ID', 'testblog2');
     $c = $this->reqGet('/testblog2/');
-    $this->assertStringNotContainsString('<h1><a href="/testblog2/', $c->getOutput());
+    $this->assertStringNotContainsString('<h1><a href="/testblog2/"', $c->getOutput());
     $this->assertStringContainsString('<h1><a href="/"', $c->getOutput());
+    Config::set('DEFAULT_BLOG_ID', null);
+  }
+
+  public function testHeaderLinkUrlNotDefaultBlogWithDefaultBlogId(): void
+  {
+    // set default blog to "testblog2"
+    Config::set('DEFAULT_BLOG_ID', 'testblog2');
+    $c = $this->reqHttpsGet('/testblog1/');
+    $this->assertStringContainsString('<h1><a href="/testblog1/"', $c->getOutput());
+    Config::set('DEFAULT_BLOG_ID', null);
+  }
+
+  public function testHeaderLinkUrlNotDefaultBlogWithOutDefaultBlogId(): void
+  {
+    // set default blog to "testblog2"
+    Config::set('DEFAULT_BLOG_ID', null);
+    $c = $this->reqHttpsGet('/testblog1/');
+    $this->assertStringContainsString('<h1><a href="/testblog1/"', $c->getOutput());
     Config::set('DEFAULT_BLOG_ID', null);
   }
 }

--- a/tests/LoaderHelper.php
+++ b/tests/LoaderHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Fc2blog\Tests;
 
 use ErrorException;
+use Fc2blog\Config;
 use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 
@@ -45,5 +46,8 @@ class LoaderHelper extends TestCase
       /** @noinspection PhpIncludeInspection このファイルはないことがあるので */
       require(TEST_APP_DIR . '/config.php');
     }
+
+    // テストではシングルテナントモードは初期オフにする、必要なテストで都度Onにする
+    Config::set('DEFAULT_BLOG_ID', null);
   }
 }


### PR DESCRIPTION
ref: #211 

(シングルテナントモードとISSUEには記述していたが、実際にはこの機能を有効にしてもマルチテナント動作はするので、名称を「デフォルトブログ機能」とする）

`/`にアクセスしたときに、指定のブログを表示する機能。
この機能実装以前は、`/`アクセス時に「登録されているブログがランダムに選択される」という動作をしていた。
個人がレンサバなどでブログを設置するときに必須となると考えて実装した。（個人的なドッグフーディングに必要と考えた）

- 実装と自動テストを作成
- 実用上のテストをもっとしていく必要があるため、一旦「実験的機能」とする
- 管理画面による変更は積み残しとして、一旦設定ファイルに記述することで指定ができるようにした
- configなどで、`DEFAULT_BLOG_ID`にblog_idの指定で設定できる
  - 環境変数で設定する場合、`FC2_DEFAULT_BLOG_ID` （`docker-compose.yml`参照）
- ルーターのユーザー系画面における詳細な挙動確認と重リファクタリング
  - 将来的にif文ベースのルーターからの脱却準備

## SS

- ![image](https://user-images.githubusercontent.com/870716/107738708-9503e500-6d4a-11eb-94bc-db200520f9a5.png)
- ![image](https://user-images.githubusercontent.com/870716/107738692-8cabaa00-6d4a-11eb-9e58-2c08b87c2fbf.png)
- ![image](https://user-images.githubusercontent.com/870716/107738733-a3520100-6d4a-11eb-8f82-6e26eafe92d6.png)

## note

E2Eテストにおいてはテストが不十分だが、稼働中に変更ができるようになる（設定をDBにもつ）ようになってから対応予定

作業時間 10h