### PR TITLE
スーパーグローバルの参照・利用を削減（$_SESSION以外）

### DIFF
--- a/app/config/fc2_template.php
+++ b/app/config/fc2_template.php
@@ -111,7 +111,7 @@ $config['fc2_template_if'] = [
 ];
 
 $template_vars = [
-  '<%server_url>' => '<?php echo \Fc2blog\Web\Html::getServerUrl() . \'/\'; ?>',
+  '<%server_url>' => '<?php echo \Fc2blog\Web\Html::getServerUrl($request) . \'/\'; ?>',
   '<%blog_id>'    => '<?php echo $blog_id; ?>',
   // タイトルリスト一覧
   '<%titlelist_eno>'          => '<?php if(isset($entry[\'id\'])) echo $entry[\'id\']; ?>',
@@ -189,8 +189,8 @@ $template_vars = [
   '<%topentry_image>'              => '<?php if(!empty($entry[\'first_image\'])) echo \'<img src="\' . $entry[\'first_image\'] . \'" />\'; ?>',
   '<%topentry_image_72>'           => '<?php if(!empty($entry[\'first_image\'])) echo \'<img src="\' . \Fc2blog\App::getThumbnailPath($entry[\'first_image\'], 72) . \'" />\'; ?>',
   '<%topentry_image_w300>'         => '<?php if(!empty($entry[\'first_image\'])) echo \'<img src="\' . \Fc2blog\App::getThumbnailPath($entry[\'first_image\'], 300, \'w\') . \'" />\'; ?>',
-  '<%topentry_image_url>'          => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl() . $entry[\'first_image\']; ?>',
-  '<%topentry_image_url_760x420>'  => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl() . \Fc2blog\App::getCenterThumbnailPath($entry[\'first_image\'], 760, 420, \'wh\'); ?>',
+  '<%topentry_image_url>'          => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl($request) . $entry[\'first_image\']; ?>',
+  '<%topentry_image_url_760x420>'  => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl($request) . \Fc2blog\App::getCenterThumbnailPath($entry[\'first_image\'], 760, 420, \'wh\'); ?>',
   '<%topentry_comment_num>'        => '<?php if(isset($entry[\'comment_count\'])) echo $entry[\'comment_count\']; ?>',
   // 記事のカテゴリー系
   '<%topentry_category_no>'        => '<?php if(!isset($entry[\'categories\'][0][\'id\'])){}else if(!empty($category) && $category[\'entry_id\']==$entry[\'categories\'][0][\'entry_id\']){'

--- a/app/src/Web/Controller/Admin/CommonController.php
+++ b/app/src/Web/Controller/Admin/CommonController.php
@@ -165,6 +165,7 @@ class CommonController extends AdminController
         // ドメイン確認
         $is_domain = DOMAIN != 'domain';
         $this->set('is_domain', $is_domain);
+        $this->set('example_server_name', $request->server['SERVER_NAME'] ?? 'example.jp');
 
         // GDインストール済み確認
         $is_gd = function_exists('gd_info');

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -174,8 +174,8 @@ abstract class Controller
   protected function redirectBack(Request $request, $url, $hash = '')
   {
     // 元のURLに戻す
-    if (!empty($_SERVER['HTTP_REFERER'])) {
-      $this->redirect($request, $_SERVER['HTTP_REFERER']);
+    if (!empty($request->server['HTTP_REFERER'])) {
+      $this->redirect($request, $request->server['HTTP_REFERER']);
     }
     // リファラーが取れなければメインへ飛ばす
     $this->redirect($request, $url, $hash);

--- a/app/src/Web/Cookie.php
+++ b/app/src/Web/Cookie.php
@@ -13,14 +13,15 @@ class Cookie
 
   /**
    * クッキーから情報を取得する
-   * @param $key
-   * @param null $default
-   * @return mixed|null
+   * @param Request $request
+   * @param string $key
+   * @param ?string $default
+   * @return mixed
    */
-  public static function get($key, $default = null)
+  public static function get(Request $request, string $key, $default = null)
   {
-    if (isset($_COOKIE[$key])) {
-      return $_COOKIE[$key];
+    if (isset($request->cookie[$key])) {
+      return $request->cookie[$key];
     }
     return $default;
   }
@@ -106,6 +107,7 @@ class Cookie
     if(defined("THIS_IS_TEST")){
       $request->cookie[$key] = $value;
     }else{
+      $request->cookie[$key] = $value;
       setcookie(
         $key,
         $value,

--- a/app/src/Web/Html.php
+++ b/app/src/Web/Html.php
@@ -244,9 +244,9 @@ class Html
     return $html;
   }
 
-  public static function getServerUrl()
+  public static function getServerUrl(Request $request): string
   {
-    $url = (empty($_SERVER["HTTPS"])) ? 'http://' : 'https://';
+    $url = (isset($request->server["HTTPS"]) && $request->server["HTTPS"] === "on") ? 'http://' : 'https://';
     $url .= Config::get('DOMAIN');
     return $url;
   }

--- a/app/src/Web/Request.php
+++ b/app/src/Web/Request.php
@@ -100,12 +100,12 @@ class Request
 
   /**
    * リファラーを返却 存在しない場合は空文字を返却
+   * @return string
    */
-  public static function getReferer()
+  public function getReferer(): string
   {
-    // TODO
-    if (!empty($_SERVER['HTTP_REFERER'])) {
-      return $_SERVER['HTTP_REFERER'];
+    if (isset($this->server['HTTP_REFERER'])) {
+      return $this->server['HTTP_REFERER'];
     }
     return '';
   }

--- a/app/src/Web/Session.php
+++ b/app/src/Web/Session.php
@@ -104,7 +104,7 @@ class Session
   {
     $_SESSION = [];
     $request->session = [];
-    if (isset($_COOKIE[Config::get('SESSION_NAME')])) {
+    if (isset($request->cookie[Config::get('SESSION_NAME')])) {
       Cookie::remove($request, Config::get('SESSION_NAME'));
     }
     if (session_status() === PHP_SESSION_ACTIVE) {

--- a/app/twig_templates/admin/common/install.twig
+++ b/app/twig_templates/admin/common/install.twig
@@ -146,7 +146,7 @@
                 <p class="ng">
                     {{ _('Domain is set to the current domain') }}<br/>
                     {{ _('Please change to the appropriate domain') }}<br/>
-                    {{ _('Example') }}) <?php echo $_SERVER["SERVER_NAME"]; ?>
+                    {{ _('Example') }}) {{ example_server_name }}
                 </p>
             {% endif %}
         </li>

--- a/tests/Helper/ClientTrait.php
+++ b/tests/Helper/ClientTrait.php
@@ -66,8 +66,11 @@ trait ClientTrait
     array $filesParams = []
   ): AppController
   {
+    // TODO ＄_をテストからも可能ならば排除する
     $_SESSION = $this->clientTraitSession;
+    // TODO ＄_COOKIEをテストからも可能ならば排除する
     $_COOKIE = $this->clientTraitCookie;
+    // TODO $_SERVERをテストからも可能ならば排除する
     $_SERVER = [];
     if ($https) {
       $_SERVER['HTTPS'] = "on";


### PR DESCRIPTION
ref: #99 

以下について、テスト以外においては削減した

-  `$_SERVER` （一部テストにのみ残存
-  `$_COOKIE` （一部テストにのみ残存
-  `$_POST`
-  `$_GET`
-  `$_FILES`
-  `$_REQUEST`
- `$_ENV`
-  `$GLOBALS`

***

- `$_SESSION`

`$_SESSION`については一通り置換してみたが、以下の問題があり、戻した。

- 深い所でグローバル変数としてあつかわれている箇所が多い（4段程度`request`を連れ回す事になる）、修正した結果見通しが悪くなる
- 現在の設計において、一部モデルの独自Validationに使われている箇所（※後述）の適切なリファクタリングが容易でない

特に後者についてはモデル周りで大きくリファクタリングをしないと適切なリファクタリングにならないため、一旦取りやめ。
モデル周りの重リファクタリングと同時に行うことにする。


※例として、
https://github.com/fc2blog/blog/blob/3d274b844f826e2121ddfc7a7e12b7a63fa52f23/app/src/Model/BlogTemplatesModel.php#L44-L56
から呼ばれる
https://github.com/fc2blog/blog/blob/7ac9372662ae5bbaf4a32d7e501c016e6165ae41/app/src/Model/Validate.php#L261-L265
https://github.com/fc2blog/blog/blob/3d274b844f826e2121ddfc7a7e12b7a63fa52f23/app/src/Model/BlogTemplatesModel.php#L75-L82
この`Session::get()`などがあるが、ここまでRequest（sessionを持っているインスタンス）をつれまわすことが困難

> バリデーションは同様の型シグネチャを持つメソッドである必要があり、なおかつ最終的なownに指定されたバリデータはデータを配列にして渡すことができない

なお、参考のために一応コミットとしてはのこしたが、これは将来もマージしない。

https://github.com/uzulla/fc2blog/commit/e0fbd88fbfdcdadb0ae590a0ab415cc03685499b

作業時間 4h