### PR TITLE
管理画面操作時のAjax通信エラーについて、エラーダイアログ等をできるだけ出すように修正

### DIFF
--- a/app/config/fc2_template.php
+++ b/app/config/fc2_template.php
@@ -111,7 +111,7 @@ $config['fc2_template_if'] = [
 ];
 
 $template_vars = [
-  '<%server_url>' => '<?php echo \Fc2blog\Web\Html::getServerUrl() . \'/\'; ?>',
+  '<%server_url>' => '<?php echo \Fc2blog\Web\Html::getServerUrl($request) . \'/\'; ?>',
   '<%blog_id>'    => '<?php echo $blog_id; ?>',
   // タイトルリスト一覧
   '<%titlelist_eno>'          => '<?php if(isset($entry[\'id\'])) echo $entry[\'id\']; ?>',
@@ -189,8 +189,8 @@ $template_vars = [
   '<%topentry_image>'              => '<?php if(!empty($entry[\'first_image\'])) echo \'<img src="\' . $entry[\'first_image\'] . \'" />\'; ?>',
   '<%topentry_image_72>'           => '<?php if(!empty($entry[\'first_image\'])) echo \'<img src="\' . \Fc2blog\App::getThumbnailPath($entry[\'first_image\'], 72) . \'" />\'; ?>',
   '<%topentry_image_w300>'         => '<?php if(!empty($entry[\'first_image\'])) echo \'<img src="\' . \Fc2blog\App::getThumbnailPath($entry[\'first_image\'], 300, \'w\') . \'" />\'; ?>',
-  '<%topentry_image_url>'          => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl() . $entry[\'first_image\']; ?>',
-  '<%topentry_image_url_760x420>'  => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl() . \Fc2blog\App::getCenterThumbnailPath($entry[\'first_image\'], 760, 420, \'wh\'); ?>',
+  '<%topentry_image_url>'          => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl($request) . $entry[\'first_image\']; ?>',
+  '<%topentry_image_url_760x420>'  => '<?php if(!empty($entry[\'first_image\'])) echo \Fc2blog\Web\Html::getServerUrl($request) . \Fc2blog\App::getCenterThumbnailPath($entry[\'first_image\'], 760, 420, \'wh\'); ?>',
   '<%topentry_comment_num>'        => '<?php if(isset($entry[\'comment_count\'])) echo $entry[\'comment_count\']; ?>',
   // 記事のカテゴリー系
   '<%topentry_category_no>'        => '<?php if(!isset($entry[\'categories\'][0][\'id\'])){}else if(!empty($category) && $category[\'entry_id\']==$entry[\'categories\'][0][\'entry_id\']){'

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -138,7 +138,7 @@ class CategoriesController extends AdminController
   }
 
   /**
-   * ajax用のカテゴリ追加
+   * ajax用のカテゴリ追加 admin/entries/create からインクルード
    * @param Request $request
    * @return string
    */

--- a/app/src/Web/Controller/Admin/CommonController.php
+++ b/app/src/Web/Controller/Admin/CommonController.php
@@ -165,6 +165,7 @@ class CommonController extends AdminController
         // ドメイン確認
         $is_domain = DOMAIN != 'domain';
         $this->set('is_domain', $is_domain);
+        $this->set('example_server_name', $request->server['SERVER_NAME'] ?? 'example.jp');
 
         // GDインストール済み確認
         $is_gd = function_exists('gd_info');

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -13,7 +13,7 @@ class FilesController extends AdminController
 {
 
   /**
-   * 一覧表示
+   * 一覧表示 /admin/files/upload からPartial読み込み
    * @param Request $request
    * @return string
    */

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -174,8 +174,8 @@ abstract class Controller
   protected function redirectBack(Request $request, $url, $hash = '')
   {
     // 元のURLに戻す
-    if (!empty($_SERVER['HTTP_REFERER'])) {
-      $this->redirect($request, $_SERVER['HTTP_REFERER']);
+    if (!empty($request->server['HTTP_REFERER'])) {
+      $this->redirect($request, $request->server['HTTP_REFERER']);
     }
     // リファラーが取れなければメインへ飛ばす
     $this->redirect($request, $url, $hash);

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -885,6 +885,7 @@ class EntriesController extends UserController
 
       // FC2用のテンプレートで表示
       $this->setAreaData(['edit_area']);
+      $this->set('sub_title', __("Edit a comment"));
       return $this->getFc2TemplatePath($blog_id);
     }
 

--- a/app/src/Web/Cookie.php
+++ b/app/src/Web/Cookie.php
@@ -13,14 +13,15 @@ class Cookie
 
   /**
    * クッキーから情報を取得する
-   * @param $key
-   * @param null $default
-   * @return mixed|null
+   * @param Request $request
+   * @param string $key
+   * @param ?string $default
+   * @return mixed
    */
-  public static function get($key, $default = null)
+  public static function get(Request $request, string $key, $default = null)
   {
-    if (isset($_COOKIE[$key])) {
-      return $_COOKIE[$key];
+    if (isset($request->cookie[$key])) {
+      return $request->cookie[$key];
     }
     return $default;
   }
@@ -106,6 +107,7 @@ class Cookie
     if(defined("THIS_IS_TEST")){
       $request->cookie[$key] = $value;
     }else{
+      $request->cookie[$key] = $value;
       setcookie(
         $key,
         $value,

--- a/app/src/Web/Html.php
+++ b/app/src/Web/Html.php
@@ -244,9 +244,9 @@ class Html
     return $html;
   }
 
-  public static function getServerUrl()
+  public static function getServerUrl(Request $request): string
   {
-    $url = (empty($_SERVER["HTTPS"])) ? 'http://' : 'https://';
+    $url = (isset($request->server["HTTPS"]) && $request->server["HTTPS"] === "on") ? 'http://' : 'https://';
     $url .= Config::get('DOMAIN');
     return $url;
   }

--- a/app/src/Web/Request.php
+++ b/app/src/Web/Request.php
@@ -100,12 +100,12 @@ class Request
 
   /**
    * リファラーを返却 存在しない場合は空文字を返却
+   * @return string
    */
-  public static function getReferer()
+  public function getReferer(): string
   {
-    // TODO
-    if (!empty($_SERVER['HTTP_REFERER'])) {
-      return $_SERVER['HTTP_REFERER'];
+    if (isset($this->server['HTTP_REFERER'])) {
+      return $this->server['HTTP_REFERER'];
     }
     return '';
   }

--- a/app/src/Web/Session.php
+++ b/app/src/Web/Session.php
@@ -104,7 +104,7 @@ class Session
   {
     $_SESSION = [];
     $request->session = [];
-    if (isset($_COOKIE[Config::get('SESSION_NAME')])) {
+    if (isset($request->cookie[Config::get('SESSION_NAME')])) {
       Cookie::remove($request, Config::get('SESSION_NAME'));
     }
     if (session_status() === PHP_SESSION_ACTIVE) {

--- a/app/twig_templates/admin/blog_plugins/index.twig
+++ b/app/twig_templates/admin/blog_plugins/index.twig
@@ -77,7 +77,11 @@
                         display: $(this).prop('checked') ? 1 : 0,
                         sig: "{{ sig }}"
                     }),
-                    cache: false
+                    cache: false,
+                    error: function (data, status, xhr){
+                        alert("エラーが発生しました、ページをリロードしてやり直してください。\n" +
+                          "An error occurred, please reload page and try again.");
+                    }
                 });
             });
 

--- a/app/twig_templates/admin/categories/ajax_add.twig
+++ b/app/twig_templates/admin/categories/ajax_add.twig
@@ -1,3 +1,4 @@
+{# include from admin/entries/create #}
 <table>
     <tbody>
     <tr>
@@ -149,6 +150,13 @@
                         addList(json.category);      // 一覧にカテゴリを追加
                     }
 
+                    $('#sys-category-add-name').val('');
+                    $('#sys-category-add').removeAttr('disabled');
+                    $('#sys-category-add').val('{{ _('Add') }}');
+                },
+                error: function (data, status, xhr){
+                    alert("カテゴリ追加時にエラーが発生しました、時間をおいてから再度試行してください。\n" +
+                      "An error occurred when adding the category, please wait a while and try again.");
                     $('#sys-category-add-name').val('');
                     $('#sys-category-add').removeAttr('disabled');
                     $('#sys-category-add').val('{{ _('Add') }}');

--- a/app/twig_templates/admin/categories/ajax_add_sp.twig
+++ b/app/twig_templates/admin/categories/ajax_add_sp.twig
@@ -1,3 +1,4 @@
+{# include from admin/entries/create #}
 <h3><span class="h3_inner">{{ _('Categories') }}</span></h3>
 
 <div class="checkbox_list">
@@ -134,6 +135,13 @@
                             addList(json.category);      // 一覧にカテゴリを追加
                         }
 
+                        $('#sys-category-add-name').val('');
+                        $('#sys-category-add').removeAttr('disabled');
+                        $('#sys-category-add').val('{{ _('Add') }}');
+                    },
+                    error: function (data, status, xhr){
+                        alert("カテゴリ追加時にエラーが発生しました、時間をおいてから再度試行してください。\n" +
+                         "An error occurred when adding the category, please wait a while and try again.");
                         $('#sys-category-add-name').val('');
                         $('#sys-category-add').removeAttr('disabled');
                         $('#sys-category-add').val('{{ _('Add') }}');

--- a/app/twig_templates/admin/comments/index.twig
+++ b/app/twig_templates/admin/comments/index.twig
@@ -170,6 +170,10 @@
                     $('#sys-reply-message').hide();
                     $('#sys-reply-error').html(json.error);
                     $('#sys-reply-error').show();
+                },
+                error: function (data, status, xhr){
+                    alert("エラーが発生しました、ページをリロードしてください。\n" +
+                    "An error occurred, please reload page and try again.");
                 }
             });
         };
@@ -193,6 +197,10 @@
                         $('#sys-open-status-' + id + ' > *').show();
                         $('#sys-comment-approval').show();
                         alert(json.error);
+                    },
+                    error: function (data, status, xhr){
+                        alert("エラーが発生しました、ページをリロードしてやり直してください。\n" +
+                          "An error occurred, please reload page and try again.");
                     }
                 });
             });

--- a/app/twig_templates/admin/comments/index.twig
+++ b/app/twig_templates/admin/comments/index.twig
@@ -143,7 +143,12 @@
             };
             $('#sys-comment-reply-dialog').dialog(option);
             $('#sys-comment-reply-dialog').html('now loading..');
-            $('#sys-comment-reply-dialog').load(common.fwURL('Comments', 'ajax_reply', {id: id}))
+            $('#sys-comment-reply-dialog').load(common.fwURL('Comments', 'ajax_reply', {id: id}), function(data, status, xhr){
+              if(status === "error") {
+                alert("エラーが発生しました、ページをリロードしてください。\n" +
+                  "An error occurred, please reload page and try again.");
+              }
+            });
             reply.updateReadStatus(is_private);
         };
         // コメントを閉じる処理

--- a/app/twig_templates/admin/common/install.twig
+++ b/app/twig_templates/admin/common/install.twig
@@ -146,7 +146,7 @@
                 <p class="ng">
                     {{ _('Domain is set to the current domain') }}<br/>
                     {{ _('Please change to the appropriate domain') }}<br/>
-                    {{ _('Example') }}) <?php echo $_SERVER["SERVER_NAME"]; ?>
+                    {{ _('Example') }}) {{ example_server_name }}
                 </p>
             {% endif %}
         </li>

--- a/app/twig_templates/admin/entries/ajax_media_load.twig
+++ b/app/twig_templates/admin/entries/ajax_media_load.twig
@@ -1,3 +1,4 @@
+{# 新規記事追加ページ /admin/entries/create から読み込み #}
 {% if files %}
 
     <ul class="sys-form-add-media">

--- a/app/twig_templates/admin/entries/ajax_media_load_sp.twig
+++ b/app/twig_templates/admin/entries/ajax_media_load_sp.twig
@@ -1,3 +1,4 @@
+{# 新規記事追加ページ /admin/entries/create SP から読み込み #}
 {% if files %}
 
     <div class="form_contents">

--- a/app/twig_templates/admin/files/ajax_index.twig
+++ b/app/twig_templates/admin/files/ajax_index.twig
@@ -1,3 +1,4 @@
+{# /admin/files/upload からPartial読み込み #}
 <h3 id="entry_count">
     {{ _('File search') }}[{{ _('Hits') }}&nbsp;{{ paging.count }}{{ _(' results') }}]
     {{ input(req, 'limit', 'select', {'options': page_list_file, 'default': file_default_limit}) }}

--- a/app/twig_templates/admin/files/ajax_index.twig
+++ b/app/twig_templates/admin/files/ajax_index.twig
@@ -113,6 +113,7 @@
                   if (status === "error") {
                     alert("エラーが発生しました、ページをリロードしてください。\n" +
                       "Request failed. Please reload page and retry.");
+                    // 失敗しているが、画面を復帰させるために検索処理を実行
                     isAjaxSubmit = isPageChange = true;
                     ajaxSubmit();
                   }

--- a/app/twig_templates/admin/files/ajax_index.twig
+++ b/app/twig_templates/admin/files/ajax_index.twig
@@ -80,7 +80,7 @@
             return false;
         });
 
-        // ファイル削除ボタン
+        // 複数ファイル削除ボタン
         $('#sys-delete-button').click(function () {
             if (!confirm('{{ _('Are you sure you want to delete?') }}')) {
                 return;
@@ -108,6 +108,14 @@
                     // 削除完了後検索処理を実行
                     isAjaxSubmit = isPageChange = true;
                     ajaxSubmit();
+                },
+                error: function( response, status, xhr ) {
+                  if (status === "error") {
+                    alert("エラーが発生しました、ページをリロードしてください。\n" +
+                      "Request failed. Please reload page and retry.");
+                    isAjaxSubmit = isPageChange = true;
+                    ajaxSubmit();
+                  }
                 }
             });
             return false;

--- a/app/twig_templates/admin/files/upload.twig
+++ b/app/twig_templates/admin/files/upload.twig
@@ -42,7 +42,7 @@
             common.formEnterNonSubmit('sys-file-form');
 
             // ajaxで一覧情報をロード
-            $('#sys-ajax-files-index').load('{{ url(req, 'Files', 'ajax_index') }}')
+            $('#sys-ajax-files-index').load('{{ url(req, 'Files', 'ajax_index') }}', writeErrToSysAjaxFilesIndex)
         });
 
         // ページ数初期化有無フラグ
@@ -64,7 +64,8 @@
                     success: function (res) {
                         $('#sys-ajax-files-index').html(res);
                         isAjaxSubmit = true;
-                    }
+                    },
+                    error: writeErrToSysAjaxFilesIndex
                 });
                 return;
             }
@@ -85,7 +86,8 @@
                 success: function (res) {
                     $('#sys-ajax-files-index').html(res);
                     isAjaxSubmit = true;
-                }
+                },
+                error: writeErrToSysAjaxFilesIndex
             });
         }
 
@@ -101,6 +103,14 @@
             }
             $('input[name=order]').val(order);
             ajaxSubmit();
+        }
+
+        function writeErrToSysAjaxFilesIndex( response, status, xhr ) {
+          if ( status === "error" ) {
+            $('#sys-ajax-files-index')
+              .html("<div style='text-align: center; font-size: 2em; font-weight:bold'>エラーが発生しました、ページをリロードしてください。<br>" +
+                "Loading error. Please reload page.</div>");
+          }
         }
     </script>
 {% endblock %}

--- a/e2e_test/tests/blog_crawl_sp.test.ts
+++ b/e2e_test/tests/blog_crawl_sp.test.ts
@@ -172,7 +172,7 @@ describe("crawl some blog with smartphone", () => {
   it("comment list - open comment form", async () => {
     const response = await c.clickElement(await getEditLinkByTitle(post_comment_title));
     expect(response.url()).toEqual(expect.stringContaining(start_url + "index.php?mode=entries&process=comment_edit&id="));
-    expect(await c.page.title()).toEqual("- testblog2"); // TODO issue #223
+    expect(await c.page.title()).toEqual("コメントの編集 - testblog2");
     await c.getSS("comment_edit_before_sp");
   });
 
@@ -214,7 +214,7 @@ describe("crawl some blog with smartphone", () => {
     await c.getSS("comment_form_delete_before2_sp");
     expect(response.status()).toEqual(200);
     expect(response.url()).toEqual(expect.stringContaining(start_url + "index.php?mode=entries&process=comment_edit&id="));
-    expect(await c.page.title()).toEqual("- testblog2"); // TODO issue #223
+    expect(await c.page.title()).toEqual("コメントの編集 - testblog2");
   });
 
   it("user template comment form - delete fail by wrong password", async () => {
@@ -250,7 +250,7 @@ describe("crawl some blog with smartphone", () => {
     await c.getSS("comment_form_delete_before2_sp");
     expect(response.status()).toEqual(200);
     expect(response.url()).toEqual(expect.stringContaining(start_url + "index.php?mode=entries&process=comment_edit&id="));
-    expect(await c.page.title()).toEqual("- testblog2"); // TODO issue #223
+    expect(await c.page.title()).toEqual("コメントの編集 - testblog2");
   });
 
   it("user template comment form - comment delete success", async () => {

--- a/public/js/admin/entry_editor.js
+++ b/public/js/admin/entry_editor.js
@@ -1,7 +1,7 @@
 // メディア追加関数
 var addMedia = {
   target_id: null,
-  elrte: true,    // elRTEの使用,不使用
+  elrte: true, // elRTEの使用,不使用
   init: function(){
     if (this.target_id!=null) {
       return ;
@@ -9,7 +9,7 @@ var addMedia = {
     // 検索ボタン
     $('#sys-add-media-search-button').on('click', function(){
       var keyword = $('#sys-add-media-search-keyword').val();
-      $('#sys-add-media-load').load(addMedia.load({keyword: keyword}));
+      addMedia.load({keyword: keyword});
     });
     // Enterキーで検索
     $('#sys-add-media-search-keyword').keypress(function(e){
@@ -71,7 +71,7 @@ var addMedia = {
     }
     $('#sys-add-media-dialog').dialog(option);
     $('#sys-add-media-load').html('<p>Now loading...</p>');
-    $('#sys-add-media-load').load(addMedia.load({}));
+    addMedia.load({});
   },
   add: function(){
     var textarea_id = addMedia.target_id;
@@ -100,7 +100,7 @@ var addMedia = {
   // 位置情報取得
   getSelection: function(dom) {
     var pos = {};
-    if (/*@cc_on!@*/false) {
+    if (/*@cc_on!@*/false) { // TODO remove, It's hack for IE<=10 #235
       dom.focus();
       var range = document.selection.createRange();
       var clone = range.duplicate();

--- a/public/js/admin/entry_editor.js
+++ b/public/js/admin/entry_editor.js
@@ -22,18 +22,27 @@ var addMedia = {
       $('#sys-add-media-dialog').dialog('option', {width: $(window).width() - 100});
     });
   },
-  load: function(params){
-    $('#sys-add-media-load').fadeOut('fast', function(){
-      $('#sys-add-media-load').load(common.fwURL('Entries', 'ajax_media_load', params), function(){
-        $('#sys-add-media-load').fadeIn('fast');
-        $('#sys-add-media-load').find('input[type=checkbox]').on('click', function(){
-          if ($(this).prop('checked')) {
-            $(this).closest('li').addClass('selected');
+  load: function (params) {
+    $('#sys-add-media-load').fadeOut('fast', function () {
+      $('#sys-add-media-load').load(
+        common.fwURL('Entries', 'ajax_media_load', params),
+        function (response, status, xhr) {
+          if (status === "error") {
+            alert("エラーが発生しました、ページをリロードしてください。\n" +
+              "Loading error. Please reload page.");
+
           } else {
-            $(this).closest('li').removeClass('selected');
+            $('#sys-add-media-load').fadeIn('fast');
+            $('#sys-add-media-load').find('input[type=checkbox]').on('click', function () {
+              if ($(this).prop('checked')) {
+                $(this).closest('li').addClass('selected');
+              } else {
+                $(this).closest('li').removeClass('selected');
+              }
+            });
           }
-        })
-      });
+        }
+      );
     });
   },
   open: function(key, config){

--- a/tests/Helper/ClientTrait.php
+++ b/tests/Helper/ClientTrait.php
@@ -66,8 +66,11 @@ trait ClientTrait
     array $filesParams = []
   ): AppController
   {
+    // TODO ＄_をテストからも可能ならば排除する
     $_SESSION = $this->clientTraitSession;
+    // TODO ＄_COOKIEをテストからも可能ならば排除する
     $_COOKIE = $this->clientTraitCookie;
+    // TODO $_SERVERをテストからも可能ならば排除する
     $_SERVER = [];
     if ($https) {
       $_SERVER['HTTPS'] = "on";

--- a/tests/cli_generate_sample_comment.php
+++ b/tests/cli_generate_sample_comment.php
@@ -6,6 +6,7 @@ use Fc2blog\Tests\Helper\SampleDataGenerator\GenerateSampleComment;
 use Fc2blog\Tests\LoaderHelper;
 
 define("TEST_APP_DIR", __DIR__ . "/../app");
+define("THIS_IS_TEST", true);
 
 require_once __DIR__ . "/../app/vendor/autoload.php";
 

--- a/tests/cli_generate_sample_upload_image.php
+++ b/tests/cli_generate_sample_upload_image.php
@@ -6,6 +6,7 @@ use Fc2blog\Tests\Helper\SampleDataGenerator\GenerateSampleUploadFile;
 use Fc2blog\Tests\LoaderHelper;
 
 define("TEST_APP_DIR", __DIR__ . "/../app");
+define("THIS_IS_TEST", true);
 
 require_once __DIR__ . "/../app/vendor/autoload.php";
 


### PR DESCRIPTION
ref: #140 

（#232 を先にマージしてください

`$.ajax`や`$(〜).load`の処理にエラーハンドリングがなく、通信エラー時などにユーザーが気づけ無いことがあるため、パーシャルロードされるコンテンツやalertにてエラーが発生したことをユーザーに掲示するようにした。

また、一部 ` $('#sys-add-media-load').load(addMedia.load({keyword: keyword}));`などの意図が不明な処理を削減した。

> `$().load`は引数としてURLを持つが、`addMedia.load`はundefを返す。

作業時間 3h