### PR TITLE
Notice, Warningなど軽微なエラーでも実行を停止させ、エラー画面を出す

### DIFF
--- a/app/config.sample.php
+++ b/app/config.sample.php
@@ -2,8 +2,7 @@
 // Sample Config file
 // Please copy `config.sample.php` to `config.php` and edit them.
 
-//error_reporting(-1);
-error_reporting(0);
+error_reporting(-1);
 
 // DBの接続情報
 define('DB_HOST', 'localhost'); // dbのホスト名
@@ -21,6 +20,10 @@ define('HTTPS_PORT', '443'); // HTTPS時ポート
 // publicとappの位置関係を修正した場合には変更してください
 // Please edit the path when change `app` and `public` relative path condition.
 define('WWW_DIR', __DIR__ . '/../public/'); // this path need finish with slash.
+
+// If you want get error log on display.
+// define('ERROR_ON_DISPLAY', "1");
+// ini_set('display_errors', '1');
 
 // 別のGitHub repoを追従する場合に設定してください
 // define('GITHUB_REPO', '/uzulla/fc2blog');

--- a/app/config_read_from_env.php
+++ b/app/config_read_from_env.php
@@ -13,6 +13,7 @@ if ((string)getenv("FC2_STRICT_ERROR_REPORT") === "1") {
 }
 
 if ((string)getenv("FC2_ERROR_ON_DISPLAY") === "1") {
+  define("ERROR_ON_DISPLAY", "1");
   ini_set('display_errors', '1');
   ini_set('display_startup_errors', '1');
   ini_set('html_errors', '1');

--- a/app/src/include/index_include.php
+++ b/app/src/include/index_include.php
@@ -1,40 +1,145 @@
-<?php
+<?php /** @noinspection PhpFullyQualifiedNameUsageInspection */
 
 declare(strict_types=1);
 
-require_once(__DIR__ . '/../../vendor/autoload.php');
+ini_set("display_errors", "0");
+ini_set("display_startup_errors", "0");
+ini_set('html_errors', "0");
+error_reporting(-1);
 
-// config.phpの存在チェック
-if (!file_exists(__DIR__ . '/../../config.php') && (string)getenv("FC2_CONFIG_FROM_ENV") !== "1") {
-  header("Content-Type: text/html; charset=UTF-8");
+// Check all errors when shutdown applications.
+register_shutdown_function(function () {
+  $error = error_get_last();
+  if (
+    !is_array($error) ||
+    !(
+      $error['type'] &
+      (E_ERROR | E_PARSE | E_CORE_ERROR | E_USER_ERROR | E_COMPILE_ERROR | E_RECOVERABLE_ERROR)
+    )
+  ) {
+    return; // normal closing.
+  }
+
+  // abnormal end. try print gentle errors.
+
+  // Logging un-excepted output buffer(debug|error messages)
+  $something = ob_get_contents();
+  if (strlen($something) > 0) {
+    error_log($something);
+  }
+  ob_end_clean();
+
+  // Error Logging
+  error_log("Uncaught Fatal Error: {$error['type']}:{$error['message']} in {$error['file']}:{$error['line']}");
+
+  // response error
+  if (!headers_sent()) {
+    http_response_code(500);
+  }
   echo <<<HTML
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-<title>Does not exists config.php</title>
-</head>
-<body>
-  Does not exists config.php / config.phpが存在しておりません
-  <p class="ng">
-    Please copy app/config.sample.php to app/config.php and edit them.<br>
-    app/config.sample.phpをapp/config.phpにコピーしファイル内に存在するDBの接続情報とサーバーの設定情報を入力してください。
-  </p>
-</body>
-</html>
-HTML;
-  exit;
-}
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+    <title>Internal Server Error</title>
+    </head>
+    <body>
+      <h1>500 Internal Server Error</h1>
+      <p>Something went wrong.</p>
+      <p>(Please check error log)</p>
+    </body>
+    </html>
+    HTML;
+});
+
+try {
+  // Catch all error (include notice/warn) and convert to ErrorException.
+  set_error_handler(function ($severity, $message, $file, $line) {
+    throw new ErrorException($message, 0, $severity, $file, $line);
+  });
+
+  // enable output buffer
+  ob_start();
+
+  require_once(__DIR__ . '/../../vendor/autoload.php');
+
+  // config.phpの存在チェック
+  if (!file_exists(__DIR__ . '/../../config.php') && (string)getenv("FC2_CONFIG_FROM_ENV") !== "1") {
+    header("Content-Type: text/html; charset=UTF-8");
+    echo <<<HTML
+      <!DOCTYPE html>
+      <html lang="ja">
+      <head>
+      <title>Does not exists config.php</title>
+      </head>
+      <body>
+        Does not exists config.php / config.phpが存在しておりません
+        <p class="ng">
+          Please copy app/config.sample.php to app/config.php and edit them.<br>
+          app/config.sample.phpをapp/config.phpにコピーしファイル内に存在するDBの接続情報とサーバーの設定情報を入力してください。
+        </p>
+      </body>
+      </html>
+      HTML;
+    return;
+  }
 
 // 設定クラス読み込み
-if ((string)getenv("FC2_CONFIG_FROM_ENV") === "1") {
-  require(__DIR__ . '/../../config_read_from_env.php');
-} else {
-  require(__DIR__ . '/../../config.php');
+  if ((string)getenv("FC2_CONFIG_FROM_ENV") === "1") {
+    require(__DIR__ . '/../../config_read_from_env.php');
+  } else {
+    /** @noinspection PhpIncludeInspection */
+    require(__DIR__ . '/../../config.php');
+  }
+  require(__DIR__ . '/bootstrap.php');
+
+  // アプリケーション実行
+  $request = new \Fc2blog\Web\Request();
+  $c = new $request->className($request);
+  $c->execute($request->methodName);
+
+  // TODO Logging un-excepted output buffer(debug|error messages|other)
+  //  $something = ob_get_contents();
+  //  if (strlen($something) > 0) {
+  //    error_log($something);
+  //  }
+  //  ob_end_clean();
+  //  ob_start();
+  // TODO remove all `echo` in app. ex: captcha
+
+  $c->emit();
+  ob_end_flush();
+  return;
+
+} catch (Throwable $e) {
+  // Uncaught Exception
+
+  // Logging un-excepted output buffer(debug|error messages)
+  $something = ob_get_contents();
+  if (strlen($something) > 0) {
+    error_log($something);
+  }
+  ob_end_clean();
+
+  // Stack trace Logging
+  $error_class_name = get_class($e);
+  error_log("Uncaught Exception {$error_class_name}: {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}\n{$e->getTraceAsString()}");
+
+  // response error
+  if (!headers_sent()) {
+    http_response_code(500);
+  }
+  echo <<<HTML
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+    <title>Internal Server Error</title>
+    </head>
+    <body>
+      <h1>500 Internal Server Error</h1>
+      <p>Something went wrong.</p>
+      <p>(Please check error log)</p>
+    </body>
+    </html>
+    HTML;
+  return;
 }
-require(__DIR__ . '/bootstrap.php');
-
-$request = new \Fc2blog\Web\Request();
-
-$c = new $request->className($request);
-$c->execute($request->methodName);
-$c->emit();

--- a/app/src/include/index_include.php
+++ b/app/src/include/index_include.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
+// For security reasons.
+// if you want set enable, please see FC2_ERROR_ON_DISPLAY in config.sample.php
 ini_set("display_errors", "0");
 ini_set("display_startup_errors", "0");
 ini_set('html_errors', "0");
-error_reporting(-1);
 
 // Check all errors when shutdown applications.
 register_shutdown_function(function () {
@@ -37,18 +38,25 @@ register_shutdown_function(function () {
     http_response_code(500);
   }
   echo <<<HTML
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-    <title>Internal Server Error</title>
-    </head>
-    <body>
-      <h1>500 Internal Server Error</h1>
-      <p>Something went wrong.</p>
-      <p>(Please check error log)</p>
-    </body>
-    </html>
-    HTML;
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+  <title>Internal Server Error</title>
+  </head>
+  <body>
+    <h1>500 Internal Server Error</h1>
+    <p>Something went wrong.</p>
+    <p>(Please check error log)</p>
+  HTML;
+  if(defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY==="1"){
+    echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><br>";
+    echo nl2br(htmlspecialchars($something.PHP_EOL, ENT_QUOTES));
+    echo nl2br(htmlspecialchars("Uncaught Fatal Error: {$error['type']}:{$error['message']} in {$error['file']}:{$error['line']}"));
+  }
+  echo <<<HTML
+  </body>
+  </html>
+  HTML;
 });
 
 try {
@@ -66,20 +74,20 @@ try {
   if (!file_exists(__DIR__ . '/../../config.php') && (string)getenv("FC2_CONFIG_FROM_ENV") !== "1") {
     header("Content-Type: text/html; charset=UTF-8");
     echo <<<HTML
-      <!DOCTYPE html>
-      <html lang="ja">
-      <head>
-      <title>Does not exists config.php</title>
-      </head>
-      <body>
-        Does not exists config.php / config.phpが存在しておりません
-        <p class="ng">
-          Please copy app/config.sample.php to app/config.php and edit them.<br>
-          app/config.sample.phpをapp/config.phpにコピーしファイル内に存在するDBの接続情報とサーバーの設定情報を入力してください。
-        </p>
-      </body>
-      </html>
-      HTML;
+    <!DOCTYPE html>
+    <html lang="ja">
+    <head>
+    <title>Does not exists config.php</title>
+    </head>
+    <body>
+      Does not exists config.php / config.phpが存在しておりません
+      <p class="ng">
+        Please copy app/config.sample.php to app/config.php and edit them.<br>
+        app/config.sample.phpをapp/config.phpにコピーしファイル内に存在するDBの接続情報とサーバーの設定情報を入力してください。
+      </p>
+    </body>
+    </html>
+    HTML;
     return;
   }
 
@@ -106,6 +114,9 @@ try {
   //  ob_start();
   // TODO remove all `echo` in app. ex: captcha
 
+  if(defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY==="1") {
+    echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><hr>";
+  }
   $c->emit();
   ob_end_flush();
   return;
@@ -129,17 +140,24 @@ try {
     http_response_code(500);
   }
   echo <<<HTML
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-    <title>Internal Server Error</title>
-    </head>
-    <body>
-      <h1>500 Internal Server Error</h1>
-      <p>Something went wrong.</p>
-      <p>(Please check error log)</p>
-    </body>
-    </html>
-    HTML;
+  <!DOCTYPE html>
+  <html lang="en">
+  <head>
+  <title>Internal Server Error</title>
+  </head>
+  <body>
+    <h1>500 Internal Server Error</h1>
+    <p>Something went wrong.</p>
+    <p>(Please check error log)</p>
+  HTML;
+  if(defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY==="1"){
+    echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><br>";
+    echo nl2br(htmlspecialchars($something.PHP_EOL, ENT_QUOTES));
+    echo nl2br(htmlspecialchars("Uncaught Exception {$error_class_name}: {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}\n{$e->getTraceAsString()}"));
+  }
+  echo <<<HTML
+  </body>
+  </html>
+  HTML;
   return;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       FC2_ERROR_LOG_PATH: "php://stderr"
       FC2_APP_LOG_PATH: "php://stderr"
       FC2_LOG_LEVEL: 100
-      FC2_ERROR_ON_DISPLAY: 1
+      FC2_ERROR_ON_DISPLAY: 0
       FC2_DB_HOST: "db"
       FC2_DB_PORT: "3306"
       FC2_DB_USER: "docker"


### PR DESCRIPTION
ref #255 

- NoticeやWarningなど、軽微な（通常そのまま処理を進行してしまう）エラーでも停止するようにした。
  - きちんとエラーをエラーとして把握し、コードクオリティを担保していくため
- キャッチされない例外、エラーが発生した歳に、エラー画面を表示することにした
  - エラー画面において、デフォルトでは詳細エラーは表示しない（セキュリティのため）
  - `ERROR_ON_DISPLAY`設定で、エラー内容の表示、非表示を設定できる
  - `ERROR_ON_DISPLAY`（FC2_ERROR_ON_DISPLAY）はあくまで調査時限定であり（エラーログをみることが前提である）、有効にし続けるものではない。常用されないように画面に警告をだすようにした。

> なお、これは回復不可能な致命的エラー（どこにもキャッチされないエラー）であり、内部ロジックできちんとキャッチされ、表示に用いる綺麗な500画面 ( #256 ) は別途作成予定。

## SS

- キャッチされなかったエラーが発生した時の表示（エラー詳細は画面にはでない、エラーログにはでる）
![image](https://user-images.githubusercontent.com/870716/111894550-f6585b80-8a4e-11eb-9d24-f8e96f33f11e.png)

- （一応、エラーログ
```
fc2blog-apache | [Sun Mar 21 05:08:19.089862 2021] [php:notice] [pid 18] [client 172.19.0.1:45778] Uncaught Exception Error: Call to undefined function Fc2blog\\Web\\Controller\\User\\a() in /fc2blog/app/src/Web/Controller/User/EntriesController.php:89\n#0 /fc2blog/app/src/Web/Controller/Controller.php(59): Fc2blog\\Web\\Controller\\User\\EntriesController->index(Object(Fc2blog\\Web\\Request))\n#1 /fc2blog/app/src/Web/Controller/Controller.php(44): Fc2blog\\Web\\Controller\\Controller->prepare('index')\n#2 /fc2blog/app/src/include/index_include.php(106): Fc2blog\\Web\\Controller\\Controller->execute('index')\n#3 /fc2blog/public/index.php(14): require('/fc2blog/app/sr...')\n#4 {main}
```

***

- `ERROR_ON_DISPLAY`有効時に、常時ヘッダーに表示される警告
![image](https://user-images.githubusercontent.com/870716/111894476-63b7bc80-8a4e-11eb-9054-bc2d46cbd682.png)

***

- `ERROR_ON_DISPLAY`有効時のエラー表示例
![image](https://user-images.githubusercontent.com/870716/111894534-a8dbee80-8a4e-11eb-856c-970e98121dc2.png)

***

作業時間 1.5h