### PR TITLE
Sigの生成をログイン時の一箇所に集約した #277

### DIFF
--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -2,6 +2,7 @@
 
 namespace Fc2blog\Web\Controller\Admin;
 
+use Fc2blog\App;
 use Fc2blog\Config;
 use Fc2blog\Web\Controller\Controller;
 use Fc2blog\Web\Request;
@@ -76,6 +77,8 @@ abstract class AdminController extends Controller
       Session::set('blog_id', $blog['id']);
       Session::set('nickname', $blog['nickname']);
     }
+
+    Session::set('sig', App::genRandomString());
   }
 
   /**

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -19,8 +19,6 @@ class BlogPluginsController extends AdminController
    */
   public function index(Request $request): string
   {
-    $request->generateNewSig();
-
     $blog_id = $this->getBlogId($request);
     $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
     $this->set('device_type', $device_type);
@@ -190,7 +188,6 @@ class BlogPluginsController extends AdminController
     // 初期表示時に編集データの設定
     if (!$request->get('blog_plugin') || !$request->isValidSig()) {
       $request->set('blog_plugin', $blog_plugin);
-      $request->generateNewSig();
       return "admin/blog_plugins/edit.twig";
     }
 
@@ -268,7 +265,6 @@ class BlogPluginsController extends AdminController
         // 未登録
         $request->set('plugin.title', $blog_plugin['title']);
       }
-      $request->generateNewSig();
       return 'admin/blog_plugins/register.twig';
     }
 

--- a/app/src/Web/Controller/Admin/BlogSettingsController.php
+++ b/app/src/Web/Controller/Admin/BlogSettingsController.php
@@ -76,7 +76,6 @@ class BlogSettingsController extends AdminController
 
     // 初期表示時に編集データの取得&設定
     if (!$request->get('blog_setting') || !$request->isValidSig()) {
-      $request->generateNewSig();
       $blog_setting = $blog_settings_model->findByBlogId($blog_id);
       $request->set('blog_setting', $blog_setting);
       return $this->get('template_path');

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -21,7 +21,6 @@ class BlogTemplatesController extends AdminController
    */
   public function index(Request $request): string
   {
-    $request->generateNewSig();
     $blog_id = $this->getBlogId($request);
     if (App::isPC($request)) {
       $device_type = $request->get('device_type', 0);
@@ -133,7 +132,7 @@ class BlogTemplatesController extends AdminController
       } else {
         $request->set('blog_template.device_type', $request->get('device_type'));
       }
-      $request->generateNewSig();
+
       return "admin/blog_templates/create.twig";
     }
 
@@ -173,7 +172,6 @@ class BlogTemplatesController extends AdminController
         $this->redirect($request, ['action' => 'index']);
       }
       $request->set('blog_template', $blog_template);
-      $request->generateNewSig();
       return "admin/blog_templates/edit.twig";
     }
 

--- a/app/src/Web/Controller/Admin/BlogsController.php
+++ b/app/src/Web/Controller/Admin/BlogsController.php
@@ -19,8 +19,6 @@ class BlogsController extends AdminController
    */
   public function index(Request $request): string
   {
-    $request->generateNewSig();
-
     // ブログの一覧取得
     $options = [
       'where' => 'user_id=?',
@@ -52,7 +50,6 @@ class BlogsController extends AdminController
   {
     // 初期表示時
     if (!$request->get('blog') || !$request->isValidSig()) {
-      $request->generateNewSig();
       return 'admin/blogs/create.twig';
     }
 
@@ -94,7 +91,6 @@ class BlogsController extends AdminController
 
     // 初期表示時に編集データの設定
     if (!$request->get('blog') || !$request->isValidSig()) {
-      $request->generateNewSig();
       if (!$blog = $blogs_model->findById($blog_id)) {
         $this->redirect($request, ['action' => 'index']);
       }
@@ -157,7 +153,6 @@ class BlogsController extends AdminController
     $this->set('tab', 'blog_delete');
     // 退会チェック
     if (!$request->get('blog.delete') || !$request->isValidSig()) {
-      $request->generateNewSig();
       return 'admin/blogs/delete.twig';
     }
 

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -42,7 +42,6 @@ class CategoriesController extends AdminController
 
     // 初期表示時
     if (!$request->get('category') || !$request->isValidSig()) {
-      $request->generateNewSig();
       return "admin/categories/create.twig";
     }
 

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -83,8 +83,6 @@ class EntriesController extends AdminController
         break;
     }
 
-    $request->generateNewSig();
-
     // オプション設定
     $options = [
       'fields' => 'entries.*',
@@ -154,7 +152,6 @@ class EntriesController extends AdminController
 
     // 初期表示時
     if (!$request->get('entry') || !$request->isValidSig()) {
-      $request->generateNewSig();
       return "admin/entries/create.twig";
     }
 
@@ -204,8 +201,6 @@ class EntriesController extends AdminController
 
     // 編集画面の表示
     if (!$request->get('entry') || !$request->isValidSig()) {
-      $request->generateNewSig();
-
       // data load
       $request->set('entry', $entry);
       $request->set('entry_categories', array('category_id' => $entry_categories_model->getCategoryIds($blog_id, $id)));

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -84,7 +84,6 @@ class FilesController extends AdminController
   {
     $files_model = new FilesModel();
     $blog_id = $this->getBlogId($request);
-    $request->generateNewSig();
 
     $this->set('file_max_size', Config::get('FILE.MAX_SIZE'));
     $this->set('page_limit_file', App::getPageLimit($request, 'FILE'));
@@ -203,7 +202,6 @@ class FilesController extends AdminController
       if (!empty($back_url)) {
         $request->set('back_url', $back_url);    // 戻る用のURL
       }
-      $request->generateNewSig();
       return 'admin/files/edit.twig';
     }
 

--- a/app/src/Web/Controller/Admin/SystemUpdateController.php
+++ b/app/src/Web/Controller/Admin/SystemUpdateController.php
@@ -14,7 +14,6 @@ class SystemUpdateController extends AdminController
   {
     // TODO unit test
 
-    $request->generateNewSig();
     $release_list = SystemUpdateModel::getReleaseInfo();
     $this->set('release_list', $release_list);
     $this->set('repo_site_url', SystemUpdateModel::getReleasesUrl());

--- a/app/src/Web/Controller/Admin/TagsController.php
+++ b/app/src/Web/Controller/Admin/TagsController.php
@@ -20,7 +20,6 @@ class TagsController extends AdminController
   {
     $tags_model = new TagsModel();
     $blog_id = $this->getBlogId($request);
-    $request->generateNewSig();
 
     $this->set('tag_limit_list', Config::get('TAG.LIMIT_LIST'));
     $this->set('tag_default_limit', Config::get('TAG.DEFAULT_LIMIT'));

--- a/app/src/Web/Controller/Admin/UsersController.php
+++ b/app/src/Web/Controller/Admin/UsersController.php
@@ -97,7 +97,6 @@ class UsersController extends AdminController
 
     // 初期表示時に編集データの取得&設定
     if (!$request->get('user') || !$request->isValidSig()) {
-      $request->generateNewSig();
       $user = $users_model->findById($user_id);
       unset($user['password']);
       $request->set('user', $user);
@@ -135,7 +134,6 @@ class UsersController extends AdminController
 
     // 退会チェック
     if (!$request->get('user.delete') || !$request->isValidSig()) {
-      $request->generateNewSig();
       return 'admin/users/withdrawal.twig';
     }
 

--- a/tests/Helper/ClientTrait.php
+++ b/tests/Helper/ClientTrait.php
@@ -45,6 +45,7 @@ trait ClientTrait
         'user_type' => 1,
         'blog_id' => 'testblog2',
         'nickname' => 'testnick2',
+        'sig' => 'test-sig'
       ],
       $this->clientTraitSession
     );
@@ -207,10 +208,9 @@ trait ClientTrait
 
   public function getSig(): string
   {
-    // sig(CSRF Token)を裏側で更新してそれを返す。
-    // TODO コントローラでsigが作られていたりいなかったりするのをどうにかしたい。
-    $this->reqGet("/admin/entries/index");
-    return $this->clientTraitSession['sig'];
+    // sig(CSRF Token)を返す。
+    $sig = $this->clientTraitSession['sig'];
+    return $sig;
   }
 
   public function getFlashMessages(): array


### PR DESCRIPTION
ref: #277

- sig（CSRF Token)が複数ヶ所で生成されており、管理画面の操作でエラーが発生しやすかった。
- sigをアクセス枚に生成する必要はないかとおもわれ（Sessionと同等の寿命でよいとおもわれ）るので、Sigをログイン時にのみ生成することとした。

作業時間 2h