### PR TITLE
セキュリティ強化のため、レスポンスヘッダー追加、リクエストヘッダーチェックを追加 #278

### DIFF
--- a/app/src/Model/BlogTemplatesModel.php
+++ b/app/src/Model/BlogTemplatesModel.php
@@ -367,4 +367,14 @@ class BlogTemplatesModel extends Model
   {
     return Config::get('APP_DIR') . 'templates/default/fc2_default_css' . Config::get('DEVICE_PREFIX.' . $device) . '.php';
   }
+
+  static public function getBodyDefaultTemplateHtmlWithDevice(string $device): string
+  {
+    return file_get_contents(static::getPathDefaultTemplateWithDevice($device));
+  }
+
+  static public function getBodyDefaultTemplateCssWithDevice(string $device): string
+  {
+    return file_get_contents(static::getPathDefaultCssWithDevice($device));
+  }
 }

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -131,6 +131,8 @@ class BlogTemplatesController extends AdminController
         ]);
       } else {
         $request->set('blog_template.device_type', $request->get('device_type'));
+        $request->set('blog_template.html', BlogTemplatesModel::getBodyDefaultTemplateHtmlWithDevice($request->get('device_type')));
+        $request->set('blog_template.css', BlogTemplatesModel::getBodyDefaultTemplateCssWithDevice($request->get('device_type')));
       }
 
       return "admin/blog_templates/create.twig";

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -143,6 +143,10 @@ class CategoriesController extends AdminController
    */
   public function ajax_add(Request $request): string
   {
+    if ($this->isInvalidAjaxRequest($request)) {
+      return $this->error403();
+    }
+
     /** @var CategoriesModel $categories_model */
     $categories_model = Model::load('Categories');
 

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -151,7 +151,7 @@ class CategoriesController extends AdminController
     $json = array('status' => 0);
 
     if (!$request->isValidSig()) {
-      $this->set('http_content_type', "application/json; charset=utf-8");
+      $this->setContentType("application/json; charset=utf-8");
       $this->setStatusCode(404);
       $this->set('json', ['error' => 'invalid sig']);
       return "admin/common/json.twig";
@@ -174,7 +174,7 @@ class CategoriesController extends AdminController
 
     $json['error'] = $errors;
 
-    $this->set('http_content_type', "application/json; charset=utf-8");
+    $this->setContentType("application/json; charset=utf-8");
     $this->set('json', $json);
     return "admin/common/json.twig";
   }

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -168,6 +168,10 @@ class CommentsController extends AdminController
    */
   public function ajax_approval(Request $request):string
   {
+    if ($this->isInvalidAjaxRequest($request)) {
+      return $this->error403();
+    }
+
     $comments_model = Model::load('Comments');
 
     $id = $request->get('id');
@@ -256,10 +260,14 @@ class CommentsController extends AdminController
   /**
    * ajax用の返信
    * @param Request $request
-   * @return string|void
+   * @return string
    */
-  public function ajax_reply(Request $request)
+  public function ajax_reply(Request $request): string
   {
+    if ($this->isInvalidAjaxRequest($request)) {
+      return $this->error403();
+    }
+
     $comments_model = new CommentsModel();
 
     $comment_id = $request->get('id');
@@ -284,19 +292,19 @@ class CommentsController extends AdminController
       return "admin/comments/ajax_reply.twig";
     }
 
-    $this->setContentType("application/json; charset=utf-8");
-
     // コメント投稿処理
     $errors = $comments_model->replyValidate($request->get('comment'), $data, ['reply_body']);
 
     if (empty($errors)) {
       if ($comments_model->updateReply($data, $comment)) {
+        $this->setContentType("application/json; charset=utf-8");
         $this->set('json', ['success' => 1]);
         return "admin/common/json.twig";
       }
     }
 
     // error だが、JS側でsuccessプロパティ存在をみて判定しているので、 status codeは200を返す
+    $this->setContentType("application/json; charset=utf-8");
     $this->set('json', ['error' => $errors['reply_body']]);
     return "admin/common/json.twig";
   }

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -177,21 +177,21 @@ class CommentsController extends AdminController
     if (!$comment = $comments_model->findByIdAndBlogId($id, $blog_id)) {
       $this->set('json', ['error' => __('Comments subject to approval does not exist')]);
       // error だが、JS側でsuccessプロパティ存在をみて判定しているので、 status codeは200を返す
-      $this->set('http_content_type', "application/json; charset=utf-8");
+      $this->setContentType("application/json; charset=utf-8");
       return "admin/common/json.twig";
     }
 
     // すでに許可済み
     if ($comment['open_status'] != Config::get('COMMENT.OPEN_STATUS.PENDING')) {
       $this->set('json', ['success' => 1]);
-      $this->set('http_content_type', "application/json; charset=utf-8");
+      $this->setContentType("application/json; charset=utf-8");
       return "admin/common/json.twig";
     }
 
     // 承認処理
     $comments_model->updateApproval($blog_id, $id);
     $this->set('json', ['success' => 1]);
-    $this->set('http_content_type', "application/json; charset=utf-8");
+    $this->setContentType("application/json; charset=utf-8");
     return "admin/common/json.twig";
   }
 
@@ -284,7 +284,7 @@ class CommentsController extends AdminController
       return "admin/comments/ajax_reply.twig";
     }
 
-    $this->set('http_content_type', "application/json; charset=utf-8");
+    $this->setContentType("application/json; charset=utf-8");
 
     // コメント投稿処理
     $errors = $comments_model->replyValidate($request->get('comment'), $data, ['reply_body']);

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -298,6 +298,10 @@ class EntriesController extends AdminController
    */
   public function ajax_media_load(Request $request)
   {
+    if ($this->isInvalidAjaxRequest($request)) {
+      return $this->error403();
+    }
+
     $files_model = new FilesModel();
     $blog_id = $this->getBlogId($request);
 

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -286,7 +286,7 @@ class FilesController extends AdminController
       $json = array('status' => 1);
     }
 
-    $this->set('http_content_type', "application/json; charset=utf-8");
+    $this->setContentType("application/json; charset=utf-8");
     $this->set('json', $json);
     return "admin/common/json.twig";
   }

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -19,6 +19,10 @@ class FilesController extends AdminController
    */
   public function ajax_index(Request $request): string
   {
+    if ($this->isInvalidAjaxRequest($request)) {
+      return $this->error403();
+    }
+
     $files_model = new FilesModel();
 
     $blog_id = $this->getBlogId($request);
@@ -280,6 +284,10 @@ class FilesController extends AdminController
    */
   public function ajax_delete(Request $request): string
   {
+    if ($this->isInvalidAjaxRequest($request)) {
+      return $this->error403();
+    }
+
     // 削除処理
     $json = array('status' => 0);
     if (!Model::load('Files')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogId($request))) {

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -33,6 +33,10 @@ abstract class Controller
   protected $output = '';  // 送信するデータ、HTML等
   private $resolvedMethod;
   protected $request;
+  protected $responseHeaders = [
+    'X-Frame-Options' => 'DENY',
+    'Content-Type' => 'text/html; charset=UTF-8',
+  ];
 
   public function __construct(Request $request)
   {
@@ -95,11 +99,8 @@ abstract class Controller
     }
 
     if (!headers_sent()) {
-      // Content typeの送信
-      if (isset($this->data['http_content_type']) && strlen($this->data['http_content_type']) > 0) {
-        header("Content-Type: {$this->getContentType()}");
-      } else {
-        header("Content-Type: text/html; charset=UTF-8");
+      foreach($this->responseHeaders as $header_name => $header_value){
+        header("{$header_name}: {$header_value}");
       }
     }
 
@@ -435,14 +436,9 @@ abstract class Controller
     $this->data['http_status_code'] = $code;
   }
 
-  public function getContentType(): string
-  {
-    return $this->data['http_content_type'];
-  }
-
   public function setContentType(string $mime_type = 'text/html; charset=UTF-8'): void
   {
-    $this->data['http_content_type'] = $mime_type;
+    $this->responseHeaders['Content-Type'] = $mime_type;
   }
 
   public function getResolvedMethod(): string

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -111,7 +111,8 @@ abstract class Controller
   {
     return (
       !isset($request->server['HTTP_X_REQUESTED_WITH']) ||
-      $request->server['HTTP_X_REQUESTED_WITH'] !== 'XMLHttpRequest'
+      $request->server['HTTP_X_REQUESTED_WITH'] !== 'XMLHttpRequest' ||
+      isset($request->server['ORIGIN'])
     );
   }
 

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -28,7 +28,9 @@ use Twig\Loader\FilesystemLoader;
 
 abstract class Controller
 {
-  protected $data = [];    // テンプレートへ渡す変数の保存領域
+  protected $data = [
+    'http_status_code' => 200
+  ];    // テンプレートへ渡す変数の保存領域
   protected $layout = '';  // 表示ページのレイアウトテンプレート
   protected $output = '';  // 送信するデータ、HTML等
   private $resolvedMethod;
@@ -94,9 +96,7 @@ abstract class Controller
    */
   public function emit(): void
   {
-    if (isset($this->data['http_status_code']) && is_int($this->data['http_status_code'])) {
-      http_response_code($this->getStatusCode());
-    }
+    http_response_code($this->getStatusCode());
 
     if (!headers_sent()) {
       foreach($this->responseHeaders as $header_name => $header_value){
@@ -105,6 +105,14 @@ abstract class Controller
     }
 
     echo $this->output;
+  }
+
+  protected function isInvalidAjaxRequest(Request $request): bool
+  {
+    return (
+      !isset($request->server['HTTP_X_REQUESTED_WITH']) ||
+      $request->server['HTTP_X_REQUESTED_WITH'] !== 'XMLHttpRequest'
+    );
   }
 
   protected function beforeFilter(Request $request)

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -112,7 +112,8 @@ abstract class Controller
     return (
       !isset($request->server['HTTP_X_REQUESTED_WITH']) ||
       $request->server['HTTP_X_REQUESTED_WITH'] !== 'XMLHttpRequest' ||
-      isset($request->server['ORIGIN'])
+      # クロスサイトアクセスは想定していない
+      isset($request->server['HTTP_ORIGIN'])
     );
   }
 

--- a/app/src/include/index_include.php
+++ b/app/src/include/index_include.php
@@ -102,6 +102,7 @@ try {
 
   // アプリケーション実行
   $request = new \Fc2blog\Web\Request();
+  /** @var \Fc2blog\Web\Controller\Controller $c */
   $c = new $request->className($request);
   $c->execute($request->methodName);
 

--- a/tests/App/Controller/Admin/Files/UploadTest.php
+++ b/tests/App/Controller/Admin/Files/UploadTest.php
@@ -21,6 +21,28 @@ class UploadTest extends TestCase
     parent::setUp();
   }
 
+  public function testWithOutXRequestedWithRequestHeader(): void
+  {
+    Session::destroy(new Request());
+    $this->resetSession();
+    $this->resetCookie();
+    $this->mergeAdminSession();
+
+    $c = $this->reqGet("/admin/files/ajax_index");
+    $this->assertEquals(200, $c->get('http_status_code'));
+
+    $c = $this->reqBase(
+      false,
+      'GET',
+      "/admin/files/ajax_index",
+      [],
+      [],
+      [],
+      false
+    );
+    $this->assertEquals(403, $c->get('http_status_code'));
+  }
+
   public function testIndexAndUploadFile(): void
   {
     Session::destroy(new Request());

--- a/tests/Helper/ClientTrait.php
+++ b/tests/Helper/ClientTrait.php
@@ -63,7 +63,8 @@ trait ClientTrait
     string $path,
     array $postParams = [],
     array $getParams = [],
-    array $filesParams = []
+    array $filesParams = [],
+    bool $addHttpXRequestedWithHeader = true
   ):  Controller
   {
     // TODO ＄_をテストからも可能ならば排除する
@@ -79,6 +80,11 @@ trait ClientTrait
     }
     $_SERVER['HTTP_USER_AGENT'] = "phpunit";
     $_SERVER['HTTP_ACCEPT_LANGUAGE'] = "ja,en-US;q=0.9,en;q=0.8";
+    if($addHttpXRequestedWithHeader) {
+      // Ajax系のreqには以下ヘッダが必須だが、現状非ajax系でも入っていても問題ないのでデフォルトでは挿入
+      // 「外れている」テストが指定したい時だけ指定
+      $_SERVER['HTTP_X_REQUESTED_WITH'] = "XMLHttpRequest";
+    }
 
     $request = new Request(
       $method,


### PR DESCRIPTION
ref #278 

#301 を先にマージしてください

- X-frame-options denyを全ページに追加（フレーム表示するケースはないと思われるので）
- `ajax_*` API系において、x-requested-with ヘッダを必須化（Ajax以外で表示するケースはないと思われるので）
- `ajax_*` API系において、Originヘッダーがある場合にはアクセスを拒否（クロスサイトで外部から取得するケースはないと思われるので）
- レスポンスヘッダー周りの処理のリファクタリング
- emitのステータスコード周りのリファクタリング
- テストの追加

作業時間 2.5h
