### PR TITLE
コメント認証ajaxをPOST化し、sigを必須に変更 #237 

### DIFF
--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -219,5 +219,17 @@ abstract class AdminController extends Controller
     $this->setStatusCode(404);
     return 'admin/common/error404.twig';
   }
+
+  /**
+   * ブログの`http(s)://FQDN(:port)`を生成する
+   * @return string
+   */
+  static public function getHostUrl(): string
+  {
+    $schema = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === "on") ? 'https:' : 'http:';
+    $domain = Config::get("DOMAIN");
+    $port = ($schema === "https:") ? Config::get("HTTPS_PORT_STR") : Config::get("HTTP_PORT_STR");
+    return $schema . "//" . $domain . $port;
+  }
 }
 

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -293,6 +293,10 @@ class CommentsController extends AdminController
     }
 
     // コメント投稿処理
+    if ($request->method !== 'POST' || !$request->isValidSig()) {
+      return $this->error403();
+    }
+
     $errors = $comments_model->replyValidate($request->get('comment'), $data, ['reply_body']);
 
     if (empty($errors)) {

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -168,7 +168,7 @@ class CommentsController extends AdminController
    */
   public function ajax_approval(Request $request):string
   {
-    if ($this->isInvalidAjaxRequest($request)) {
+    if ($this->isInvalidAjaxRequest($request) || $request->method !== 'POST' || !$request->isValidSig()) {
       return $this->error403();
     }
 

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -284,7 +284,7 @@ class FilesController extends AdminController
    */
   public function ajax_delete(Request $request): string
   {
-    if ($this->isInvalidAjaxRequest($request)) {
+    if ($this->isInvalidAjaxRequest($request) || $request->method !== 'POST' || !$request->isValidSig()) {
       return $this->error403();
     }
 

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -109,12 +109,23 @@ abstract class Controller
 
   protected function isInvalidAjaxRequest(Request $request): bool
   {
-    return (
+    # HTTP_X_REQUESTED_WITHを検証
+    if(
       !isset($request->server['HTTP_X_REQUESTED_WITH']) ||
-      $request->server['HTTP_X_REQUESTED_WITH'] !== 'XMLHttpRequest' ||
-      # クロスサイトアクセスは想定していない
-      isset($request->server['HTTP_ORIGIN'])
-    );
+      $request->server['HTTP_X_REQUESTED_WITH'] !== 'XMLHttpRequest'
+    ) {
+      return true;
+    }
+
+    # ORIGINを検証
+    if(
+      isset($request->server['HTTP_ORIGIN']) &&
+      $request->server['HTTP_ORIGIN'] !== AdminController::getHostUrl()
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   protected function beforeFilter(Request $request)

--- a/app/twig_templates/admin/comments/index.twig
+++ b/app/twig_templates/admin/comments/index.twig
@@ -196,8 +196,9 @@
             }
             $('#sys-comment-approval').hide();
             $.ajax({
-                type: 'GET',
-                url: common.fwURL('comments', 'ajax_approval', {id: id}),
+                type: 'POST',
+                url: common.fwURL('comments', 'ajax_approval'),
+                data: {id: id, sig: '{{ sig }}'},
                 dataType: 'json',
                 success: function (json) {
                     if (json.success) {

--- a/app/twig_templates/admin/comments/index.twig
+++ b/app/twig_templates/admin/comments/index.twig
@@ -168,8 +168,8 @@
             $('#sys-reply-message').show();
             $.ajax({
                 type: 'POST',
-                url: common.fwURL('comments', 'ajax_reply', {id: id}),
-                data: {comment: {reply_body: $('textarea[name="comment[reply_body]"]').val()}},
+                url: common.fwURL('comments', 'ajax_reply'),
+                data: {id: id, sig: '{{ sig }}', comment: {reply_body: $('textarea[name="comment[reply_body]"]').val()}},
                 dataType: 'json',
                 success: function (json) {
                     if (json.success) {

--- a/app/twig_templates/admin/comments/index.twig
+++ b/app/twig_templates/admin/comments/index.twig
@@ -195,26 +195,24 @@
                 return;
             }
             $('#sys-comment-approval').hide();
-            $('#sys-open-status-' + id + ' > *').fadeOut('fast', function () {
-                $.ajax({
-                    type: 'GET',
-                    url: common.fwURL('comments', 'ajax_approval', {id: id}),
-                    dataType: 'json',
-                    success: function (json) {
-                        if (json.success) {
-                            $('#sys-open-status-' + id).html('<span class="published">{{ _('Published') }}</span>');
-                            $('#sys-open-status').html('<span class="published">{{ _('Published') }}</span>');
-                            return;
-                        }
-                        $('#sys-open-status-' + id + ' > *').show();
-                        $('#sys-comment-approval').show();
-                        alert(json.error);
-                    },
-                    error: function (data, status, xhr){
-                        alert("エラーが発生しました、ページをリロードしてやり直してください。\n" +
-                          "An error occurred, please reload page and try again.");
+            $.ajax({
+                type: 'GET',
+                url: common.fwURL('comments', 'ajax_approval', {id: id}),
+                dataType: 'json',
+                success: function (json) {
+                    if (json.success) {
+                        $('#sys-open-status-' + id + ' > *').fadeOut('fast');
+                        $('#sys-open-status-' + id).html('<span class="published">{{ _('Published') }}</span>');
+                        $('#sys-open-status').html('<span class="published">{{ _('Published') }}</span>');
+                        return;
                     }
-                });
+                    $('#sys-comment-approval').show();
+                    alert(json.error);
+                },
+                error: function (data, status, xhr){
+                    alert("エラーが発生しました、ページをリロードしてやり直してください。\n" +
+                      "An error occurred, please reload page and try again.");
+                }
             });
         };
 


### PR DESCRIPTION
ref: #237

- コメント認証をPOST化（API、フロントエンドJS修正）
- コメント返信`ajax_reply`にてsigチェックが不足していたので追加
- ファイル削除 `ajax_delete`にてsigチェックが不足していたので追加
- ORIGINヘッダチェックを一部条件にて有効化
- ORIGINチェックのために、管理画面の`http(s)://FQDN(:port)`を生成する `getHostUrl()`を`AdminController`に追加
- コメント認証時に、リクエスト失敗時でもボタンが消えるのを、リクエスト成功時にボタンを消すように修正

## note

今回の修正で、ajax更新系はsig必須&POST必須になりました

作業時間: 2.5h