### PR TITLE
エントリ作成の画像ファイル選択から画像をULする機能追加 #243

### DIFF
--- a/app/twig_templates/admin/entries/editor_js.twig
+++ b/app/twig_templates/admin/entries/editor_js.twig
@@ -30,6 +30,9 @@
     <div id="sys-add-media-search">
         <input type="text" id="sys-add-media-search-keyword"/>
         <input type="button" value="{{ _('Search') }}" id="sys-add-media-search-button"/>
+        /
+        <input id="ajax_file_upload_file" type="file" name="file[file]">
+        <button type="button" onclick="ajax_file_upload('{{ sig }}');">{{ _('Upload') }}</button>
     </div>
     <hr/>
 

--- a/public/assets/admin/js/entry_editor.js
+++ b/public/assets/admin/js/entry_editor.js
@@ -138,7 +138,48 @@ var addMedia = {
 };
 
 // 画面外クリック時にダイアログを閉じる処理
-$(document).on('click', '.ui-widget-overlay', function(){
+$(document).on('click', '.ui-widget-overlay', function () {
   $(this).prev().find('.ui-dialog-content').dialog('close');
 });
 
+// 画像選択ダイアログ内からのファイルアップロード
+const ajax_file_upload = (sig) => {
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', common.fwURL('Files', 'ajax_file_upload'));
+  xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+  xhr.onreadystatechange = function () {
+    if (xhr.readyState === 4) {
+      const data = JSON.parse(xhr.response);
+      if (data && data.status === "ok") {
+        $('#sys-add-media-load').load(
+            common.fwURL('Entries', 'ajax_media_load'),
+            function (response, status, xhr) {
+              if (status === "error") {
+                alert("エラーが発生しました、ページをリロードしてください。\n" +
+                    "Loading error. Please reload page.");
+              } else {
+                $('#sys-add-media-load').fadeIn('fast');
+                $('#sys-add-media-load').find('input[type=checkbox]').on('click', function () {
+                  if ($(this).prop('checked')) {
+                    $(this).closest('li').addClass('selected');
+                  } else {
+                    $(this).closest('li').removeClass('selected');
+                  }
+                });
+              }
+            }
+        );
+      } else {
+        alert("エラーが発生しました、ページをリロードしてください。\n" +
+            "Loading error. Please reload page.");
+      }
+    }
+  }
+
+  const form = new FormData();
+  const file_elm = document.getElementById("ajax_file_upload_file");
+  form.append('sig', sig);
+  form.append(file_elm.name, file_elm.files[0], file_elm.files[0].name);
+
+  xhr.send(form);
+}


### PR DESCRIPTION
ref: #243 

- 以下スクショの通り、ダイアログからファイルを選択し、アップロード完了後にダイアログ内容がリロードされ、選択できる。いちいちファイルアップロード画面に遷移しなくてもよい。
- ![image](https://user-images.githubusercontent.com/870716/118650181-2047b780-b81f-11eb-92f1-c59284a36f44.png)
- ![image](https://user-images.githubusercontent.com/870716/118650296-3bb2c280-b81f-11eb-8319-14bd741e52e3.png)

作業時間 2.5h