### PR TITLE
エントリ作成・編集画面にて、保存失敗時にタグ設定が復帰するように修正 #283

### DIFF
--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -128,7 +128,11 @@ class EntriesController extends AdminController
         $blog_id = $this->getBlogId($request);
 
         // data load
-        $this->set('entry_tags', $tags_model->getWellUsedTags($blog_id));
+        if (is_null($request->get('entry_tags'))) {
+            $this->set('entry_tags', $tags_model->getWellUsedTags($blog_id));
+        } else {
+            $this->set('entry_tags', $request->get('entry_tags'));
+        }
         $this->set('open_status_list', EntriesModel::getOpenStatusList());
         $this->set('open_status_open', Config::get('ENTRY.OPEN_STATUS.OPEN'));
         $this->set('auto_line_feed_list', EntriesModel::getAutoLinefeedList());

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -133,6 +133,7 @@ class EntriesController extends AdminController
         } else {
             $this->set('entry_tags', $request->get('entry_tags'));
         }
+        $this->set('well_use_entry_tags', $tags_model->getWellUsedTags($blog_id));
         $this->set('open_status_list', EntriesModel::getOpenStatusList());
         $this->set('open_status_open', Config::get('ENTRY.OPEN_STATUS.OPEN'));
         $this->set('auto_line_feed_list', EntriesModel::getAutoLinefeedList());
@@ -210,7 +211,8 @@ class EntriesController extends AdminController
             $request->set('entry_categories', array('category_id' => $entry_categories_model->getCategoryIds($blog_id, $id)));
             $request->set('entry_tags', $tags_model->getEntryTagNames($blog_id, $id));   // タグの文字列をテーブルから取得
 
-            $this->set('entry_tags', $tags_model->getWellUsedTags($blog_id));
+            $this->set('entry_tags', $tags_model->getEntryTagNames($blog_id, $id));
+            $this->set('well_use_entry_tags', $tags_model->getWellUsedTags($blog_id));
             $this->set('open_status_list', EntriesModel::getOpenStatusList());
             $this->set('open_status_open', Config::get('ENTRY.OPEN_STATUS.OPEN'));
             $this->set('auto_line_feed_list', EntriesModel::getAutoLinefeedList());
@@ -262,6 +264,7 @@ class EntriesController extends AdminController
         $this->set('comment_accepted_accepted', Config::get('ENTRY.COMMENT_ACCEPTED.ACCEPTED'));
         $this->set('open_status_password', Config::get('ENTRY.OPEN_STATUS.PASSWORD'));
         $this->set('lang_elrte', Config::get('LANG_ELRTE.' . Config::get('LANG')));
+        $this->set('well_use_entry_tags', $tags_model->getWellUsedTags($blog_id));
         $this->set('entry_tags', $request->get('entry_tags'));
         $this->set('entry_categories', $request->get('entry_categories', array('category_id' => array())));
         $this->set('categories', $categories_model->getList($blog_id));

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -262,6 +262,7 @@ class EntriesController extends AdminController
         $this->set('comment_accepted_accepted', Config::get('ENTRY.COMMENT_ACCEPTED.ACCEPTED'));
         $this->set('open_status_password', Config::get('ENTRY.OPEN_STATUS.PASSWORD'));
         $this->set('lang_elrte', Config::get('LANG_ELRTE.' . Config::get('LANG')));
+        $this->set('entry_tags', $request->get('entry_tags'));
         $this->set('entry_categories', $request->get('entry_categories', array('category_id' => array())));
         $this->set('categories', $categories_model->getList($blog_id));
         // 以下はSPテンプレ用で追加

--- a/app/twig_templates/admin/entries/form.twig
+++ b/app/twig_templates/admin/entries/form.twig
@@ -36,7 +36,7 @@
                 <input type="button" value="{{ _('Add') }}" id="sys-add-tag-button"/>
                 <ul id="sys-add-tags"></ul>
                 <ul id="sys-use-well-tags">
-                    {% for tag in tags %}
+                    {% for tag in entry_tags %}
                         <li>{{ tag }}</li>
                     {% endfor %}
                 </ul>

--- a/app/twig_templates/admin/entries/form.twig
+++ b/app/twig_templates/admin/entries/form.twig
@@ -36,7 +36,7 @@
                 <input type="button" value="{{ _('Add') }}" id="sys-add-tag-button"/>
                 <ul id="sys-add-tags"></ul>
                 <ul id="sys-use-well-tags">
-                    {% for tag in entry_tags %}
+                    {% for tag in well_use_entry_tags %}
                         <li>{{ tag }}</li>
                     {% endfor %}
                 </ul>


### PR DESCRIPTION
#283 

- タグ一覧がでてこないバグを修正
- 新規作成時、保存時に送信されたタグでなく、既存タグが表示されるのを修正
- 編集時、タグ一覧が表示されない（復帰もしない）バグを修正
- 「よく使うタグ」と「編集中（保存用）タグ」が混ざっていたので分割

## note

- ISSUEに記載してあった「カテゴリ追加」フィールドの復帰は、あの時点で保存されていれば復帰する（保存していないものは保持する必要はない）ために対応無し。

作業時間 1.2h