### PR TITLE
Controller周辺のリファクタリング、型の厳格化、コードのデカップリング等 #108 #256

### DIFF
--- a/app/src/Config.php
+++ b/app/src/Config.php
@@ -73,7 +73,7 @@ class Config
      * @param string $name
      * @param bool $force_reload UnitTest内などで再読み込みを強制したい場合に指定
      */
-    public static function read(string $name, $force_reload = false)
+    public static function read(string $name, bool $force_reload = false)
     {
         if (!$force_reload && !empty(self::$read_files[$name])) {
             // 既に読み込み済みのファイルは読み込まないが、強制的に再読み込みの指定があれば読み込みする。

--- a/app/src/Lib/CaptchaImage.php
+++ b/app/src/Lib/CaptchaImage.php
@@ -20,7 +20,7 @@ class CaptchaImage
      * @param $src_img_size_y 1 以上が必要
      * @param bool $hirakana_mode
      */
-    public function __construct($src_img_size_x, $src_img_size_y, $hirakana_mode = true)
+    public function __construct($src_img_size_x, $src_img_size_y, bool $hirakana_mode = true)
     {
         $this->img_size_x = $src_img_size_x;
         $this->img_size_y = $src_img_size_y;
@@ -33,7 +33,7 @@ class CaptchaImage
      * @param bool $mini_mode
      * @throws Exception
      */
-    public function drawNumber($number, $mini_mode = false): void
+    public function drawNumber($number, bool $mini_mode = false): void
     {
         //memo. sjisの書体はサーバー環境によっては使えない
         $arr_fonts = array(

--- a/app/src/Model/ArrayIterableTrait.php
+++ b/app/src/Model/ArrayIterableTrait.php
@@ -17,6 +17,7 @@ trait ArrayIterableTrait
         $props = (new ReflectionClass(static::class))->getProperties();
         foreach ($props as $prop) {
             $name = $prop->getName();
+            if (preg_match("/@dynamic/u", (string)$prop->getDocComment())) continue;
             $self->{$name} = $list[$name];
         }
         return $self;
@@ -43,11 +44,21 @@ trait ArrayIterableTrait
         $r = new ReflectionClass(static::class);
         try {
             $prop = $r->getProperty($offset);
+// # Dynamicにプロパティを追加しようとした時の一時的回避パッチ。遭遇したら以下を生やす
+// # /** @dynamic */
+// # public $url;
+//        } catch (ReflectionException $e) {
+//            // 取得できない場合、無いプロパティを動的に生やす。最終的にはこの箇所はなくす。
+//            $this->{$offset} = $value;
+//            error_log("WARN: found undefined dynamic property {$offset} to ".static::class);
+//            return;
+//        }
+//        try {
             if ($prop->isPublic()) {
                 $this->{$prop->getName()} = $value;
             }
         } catch (ReflectionException $e) {
-            throw new LogicException("touch missing property " . $e->getMessage());
+            throw new LogicException("touch missing property " . $e->getMessage() . " at " . $e->getFile() . ":" . $e->getLine());
         }
     }
 

--- a/app/src/Model/Blog.php
+++ b/app/src/Model/Blog.php
@@ -27,4 +27,8 @@ class Blog implements ArrayAccess, IteratorAggregate, Countable
     public $last_posted_at;
     public $created_at;
     public $updated_at;
+
+    // === Not available in DB, Dynamic properties
+    /** @dynamic */
+    public $url;
 }

--- a/app/src/Model/BlogPluginsModel.php
+++ b/app/src/Model/BlogPluginsModel.php
@@ -5,6 +5,7 @@ namespace Fc2blog\Model;
 use Fc2blog\App;
 use Fc2blog\Config;
 use Fc2blog\Util\PhpCodeLinter;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Session;
 
 class BlogPluginsModel extends Model
@@ -161,7 +162,7 @@ class BlogPluginsModel extends Model
         }
 
         // HTMLをPHPテンプレートに変換してテンプレートファイルの作成
-        $html = BlogTemplatesModel::convertFC2Template($php_code);
+        $html = Fc2BlogTemplate::convertToPhp($php_code);
         file_put_contents($plugin_path, $html);
         chmod($plugin_path, 0777);
 
@@ -426,7 +427,7 @@ class BlogPluginsModel extends Model
         }
 
         // HTMLをPHPテンプレートに変換してテンプレートファイルの作成
-        $html = BlogTemplatesModel::convertFC2Template($html);
+        $html = Fc2BlogTemplate::convertToPhp($html);
         file_put_contents($plugin_path, $html);
         chmod($plugin_path, 0777);
     }

--- a/app/src/Model/BlogsModel.php
+++ b/app/src/Model/BlogsModel.php
@@ -310,10 +310,10 @@ class BlogsModel extends Model
 
     /**
      * ユーザーIDをキーにブログのリストを取得
-     * @param string $user_id
+     * @param int $user_id
      * @return mixed
      */
-    public function getListByUserId(string $user_id)
+    public function getListByUserId(int $user_id)
     {
         return $this->find('list', array(
             'fields' => array('id', 'name'),

--- a/app/src/Model/BlogsModel.php
+++ b/app/src/Model/BlogsModel.php
@@ -621,13 +621,13 @@ class BlogsModel extends Model
     /**
      * Blog 設定が今アクセスしているSchemaと一致しているか確認
      * @param Request $request
-     * @param array $blog blog array
+     * @param Blog $blog blog array
      * @return bool
      */
-    static public function isCorrectHttpSchemaByBlogArray(Request $request, array $blog): bool
+    static public function isCorrectHttpSchemaByBlog(Request $request, Blog $blog): bool
     {
         $is_https = (isset($request->server['HTTPS']) && $request->server['HTTPS'] == 'on');
-        return ($blog['ssl_enable'] === 1 && $is_https) || ($blog['ssl_enable'] === 0 && !$is_https);
+        return ($blog->ssl_enable === 1 && $is_https) || ($blog->ssl_enable === 0 && !$is_https);
     }
 
     /**

--- a/app/src/Service/BlogService.php
+++ b/app/src/Service/BlogService.php
@@ -8,8 +8,10 @@ use Fc2blog\Model\BlogsModel;
 
 class BlogService
 {
-    public static function getById(string $blog_id): ?Blog
+    public static function getById(?string $blog_id): ?Blog
     {
+        if (is_null($blog_id)) return null;
+
         $repo = new BlogsModel();
         $res = $repo->findById($blog_id);
         if ($res === false) return null;

--- a/app/src/Util/PhpCodeLinter.php
+++ b/app/src/Util/PhpCodeLinter.php
@@ -14,7 +14,7 @@ class PhpCodeLinter
      * @param $string
      * @return bool
      */
-    public static function isParsablePhpCode($string)
+    public static function isParsablePhpCode($string): bool
     {
         $parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
         try {

--- a/app/src/Util/StringCaseConverter.php
+++ b/app/src/Util/StringCaseConverter.php
@@ -1,12 +1,12 @@
 <?php
-
 declare(strict_types=1);
 
 namespace Fc2blog\Util;
 
+use InvalidArgumentException;
+
 class StringCaseConverter
 {
-
     /**
      * パスカルケースへの変換
      * @param string $snake_case
@@ -14,6 +14,7 @@ class StringCaseConverter
      */
     public static function pascalCase(string $snake_case): string
     {
+        if (preg_match('/[^a-zA-Z0-9_ ]/u', $snake_case)) throw new InvalidArgumentException("contain non allowable string {$snake_case}");
         $snake_case = str_replace('_', ' ', $snake_case);
         $snake_case = ucwords($snake_case);
         return str_replace(' ', '', $snake_case);
@@ -26,6 +27,7 @@ class StringCaseConverter
      */
     public static function camelCase(string $snake_case): string
     {
+        if (preg_match('/[^a-zA-Z0-9_ ]/u', $snake_case)) throw new InvalidArgumentException("contain non allowable string {$snake_case}");
         return lcfirst(static::pascalCase($snake_case));
     }
 
@@ -36,6 +38,7 @@ class StringCaseConverter
      */
     public static function snakeCase(string $camel_case): string
     {
+        if (preg_match('/[^a-zA-Z0-9_ ]/u', $camel_case)) throw new InvalidArgumentException("contain non allowable string {$camel_case}");
         return strtolower(preg_replace("/([A-Z])/u", "_$0", lcfirst($camel_case)));
     }
 }

--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -169,37 +169,37 @@ abstract class AdminController extends Controller
 
     /**
      * 情報用メッセージを設定する
-     * @param $message
+     * @param string $message
      */
-    protected function setInfoMessage($message): void
+    protected function setInfoMessage(string $message): void
     {
         $this->setMessage($message, 'flash-message-info');
     }
 
     /**
      * 警告用メッセージを設定する
-     * @param $message
+     * @param string $message
      */
-    protected function setWarnMessage($message): void
+    protected function setWarnMessage(string $message): void
     {
         $this->setMessage($message, 'flash-message-warn');
     }
 
     /**
      * エラー用メッセージを設定する
-     * @param $message
+     * @param string $message
      */
-    protected function setErrorMessage($message): void
+    protected function setErrorMessage(string $message): void
     {
         $this->setMessage($message, 'flash-message-error');
     }
 
     /**
      * メッセージを設定する
-     * @param $message
-     * @param $type
+     * @param string $message
+     * @param string $type
      */
-    protected function setMessage($message, $type): void
+    protected function setMessage(string $message, string $type): void
     {
         $messages = Session::get($type, array());
         $messages[] = $message;
@@ -208,6 +208,7 @@ abstract class AdminController extends Controller
 
     /**
      * メッセージ情報を削除し取得する
+     * @return array<string, string>
      */
     protected function removeMessage(): array
     {

--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -221,7 +221,7 @@ abstract class AdminController extends Controller
     }
 
     // 404 NotFound Action
-    public function error404(): string
+    protected function error404(): string
     {
         $this->setStatusCode(404);
         return 'admin/common/error404.twig';

--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -61,7 +61,7 @@ abstract class AdminController extends Controller
         }
 
         // ログイン中でかつブログ選択中の場合ブログ情報を取得し時間設定を行う
-        $blog = BlogService::getById($this->getBlogId($request));
+        $blog = BlogService::getById($this->getBlogIdFromSession());
         if (is_array($blog) && isset($blog['timezone'])) {
             date_default_timezone_set($blog['timezone']);
         }
@@ -144,13 +144,10 @@ abstract class AdminController extends Controller
     }
 
     /**
-     * ブログIDを取得する
-     * @param Request $request
-     * @return mixed|null
-     * // TODO 現在ではrequestが不要なので消し込み
-     * @noinspection PhpUnusedParameterInspection
+     * セッションに保持された現在のBlog IDを取得する、未設定の場合はNULL
+     * @return string|null
      */
-    protected function getBlogId(Request $request)
+    protected function getBlogIdFromSession(): ?string
     {
         return Session::get('blog_id');
     }

--- a/app/src/Web/Controller/Admin/AdminController.php
+++ b/app/src/Web/Controller/Admin/AdminController.php
@@ -221,12 +221,6 @@ abstract class AdminController extends Controller
         return $messages;
     }
 
-    // 存在しないアクションは404へ
-    public function __call($name, $arguments): string
-    {
-        return $this->error404();
-    }
-
     // 404 NotFound Action
     public function error404(): string
     {

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -8,7 +8,6 @@ use Fc2blog\Model\BlogPluginsModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Model\PluginsModel;
 use Fc2blog\Web\Request;
-use Fc2blog\Web\Session;
 
 class BlogPluginsController extends AdminController
 {
@@ -61,7 +60,7 @@ class BlogPluginsController extends AdminController
      * @param Request $request
      * @return string
      */
-    public function share_search(Request $request)
+    public function share_search(Request $request): string
     {
         return $this->plugin_search($request, false);
     }
@@ -72,7 +71,7 @@ class BlogPluginsController extends AdminController
      * @param bool $is_official
      * @return string
      */
-    private function plugin_search(Request $request, $is_official = true): string
+    private function plugin_search(Request $request, bool $is_official = true): string
     {
         $plugins_model = new PluginsModel();
 
@@ -134,8 +133,7 @@ class BlogPluginsController extends AdminController
         $this->set('template_syntaxes', $template_syntaxes);
 
         // 初期表示時
-        if (!$request->get('blog_plugin') || !Session::get('sig') || Session::get('sig') !== $request->get('sig')) {
-            Session::set('sig', App::genRandomString());
+        if (!$request->get('blog_plugin') || !$request->isValidSig()) {
             $request->set('blog_plugin', array(
                 'device_type' => $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES')),
                 'category' => $request->get('category', 1),
@@ -226,7 +224,7 @@ class BlogPluginsController extends AdminController
             $this->redirect($request, array('action' => 'index'));
         }
 
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 削除処理
             $blog_plugins_model->deleteByIdAndBlogId($id, $blog_id);
             $this->setInfoMessage(__('I removed the plugin'));
@@ -305,7 +303,7 @@ class BlogPluginsController extends AdminController
             $this->redirect($request, array('action' => 'search'));
         }
 
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 削除処理
             $plugins_model->deleteByIdAndUserId($id, $user_id);
             $this->setInfoMessage(__('I removed the plugin'));
@@ -326,7 +324,7 @@ class BlogPluginsController extends AdminController
             $this->redirectBack($request, array('controller' => 'blog_plugins', 'action' => 'index'));
         }
 
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 追加用のデータを取得データから作成
             $blog_plugin_data = array(
                 'title' => $plugin['title'],
@@ -379,7 +377,7 @@ class BlogPluginsController extends AdminController
         $blog_id = $this->getBlogIdFromSession();
         $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
 
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // プラグインの表示可否の一括変更
             $blog_plugins_model->updateDisplay($request->get('blog_plugins'), $blog_id);
             $this->setInfoMessage(__('I changed the display settings'));
@@ -404,7 +402,7 @@ class BlogPluginsController extends AdminController
         $display = $request->get('display') ? Config::get('APP.DISPLAY.SHOW') : Config::get('APP.DISPLAY.HIDE');  // 表示可否
 
         // 編集対象のデータ取得
-        if (!$blog_plugins_model->findByIdAndBlogId($id, $blog_id) || !Session::get('sig') || Session::get('sig') !== $request->get('sig')) {
+        if (!$blog_plugins_model->findByIdAndBlogId($id, $blog_id) || !$request->isValidSig()) {
             $this->redirect($request, array('action' => 'index'));
         }
 

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -19,7 +19,7 @@ class BlogPluginsController extends AdminController
      */
     public function index(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
         $this->set('device_type', $device_type);
         $this->set('devices', Config::get('DEVICE_NAME'));
@@ -148,7 +148,7 @@ class BlogPluginsController extends AdminController
         $white_list = array('title', 'title_align', 'title_color', 'contents', 'contents_align', 'contents_color', 'device_type', 'category');
         $errors['blog_plugin'] = $blog_plugins_model->validate($request->get('blog_plugin'), $blog_plugin_data, $white_list);
         if (empty($errors['blog_plugin'])) {
-            $blog_plugin_data['blog_id'] = $this->getBlogId($request);
+            $blog_plugin_data['blog_id'] = $this->getBlogIdFromSession();
             if ($blog_plugins_model->insert($blog_plugin_data)) {
                 $this->setInfoMessage(__('I created a plugin'));
                 $this->redirect($request, array('action' => 'index', 'device_type' => $blog_plugin_data['device_type']));
@@ -172,7 +172,7 @@ class BlogPluginsController extends AdminController
         $blog_plugins_model = Model::load('BlogPlugins');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->set('blog_plugin_attribute_align', BlogPluginsModel::getAttributeAlign());
         $this->set('blog_plugin_attribute_color', BlogPluginsModel::getAttributeColor());
@@ -218,7 +218,7 @@ class BlogPluginsController extends AdminController
         $blog_plugins_model = Model::load('BlogPlugins');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 削除データの取得
         $blog_plugin = $blog_plugins_model->findByIdAndBlogId($id, $blog_id);
@@ -245,7 +245,7 @@ class BlogPluginsController extends AdminController
         $blog_plugins_model = new BlogPluginsModel();
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 登録データの取得
         $blog_plugin = $blog_plugins_model->findByIdAndBlogId($id, $blog_id);
@@ -336,7 +336,7 @@ class BlogPluginsController extends AdminController
             );
 
             // 新規登録処理
-            $blog_plugin_data['blog_id'] = $this->getBlogId($request);
+            $blog_plugin_data['blog_id'] = $this->getBlogIdFromSession();
             if (Model::load('BlogPlugins')->insert($blog_plugin_data)) {
                 $this->setInfoMessage(__('I created a plugin'));
                 $this->redirect($request, array('action' => 'index', 'device_type' => $plugin['device_type']));
@@ -355,7 +355,7 @@ class BlogPluginsController extends AdminController
     {
         $blog_plugins_model = Model::load('BlogPlugins');
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
 
         // 並べ替え処理
@@ -376,7 +376,7 @@ class BlogPluginsController extends AdminController
     {
         $blog_plugins_model = Model::load('BlogPlugins');
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
 
         if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
@@ -400,7 +400,7 @@ class BlogPluginsController extends AdminController
         $blog_plugins_model = Model::load('BlogPlugins');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $display = $request->get('display') ? Config::get('APP.DISPLAY.SHOW') : Config::get('APP.DISPLAY.HIDE');  // 表示可否
 
         // 編集対象のデータ取得

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 
@@ -19,7 +20,7 @@ class BlogPluginsController extends AdminController
     public function index(Request $request): string
     {
         $blog_id = $this->getBlogIdFromSession();
-        $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
+        $device_type = $request->get('device_type', (string)Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
         $this->set('device_type', $device_type);
         $this->set('devices', Config::get('DEVICE_NAME'));
 
@@ -76,7 +77,7 @@ class BlogPluginsController extends AdminController
         $plugins_model = new PluginsModel();
 
         // デバイスタイプの取得
-        $device_type = $request->get('device_type', Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
+        $device_type = $request->get('device_type', (string)Config::get('DEVICE_PC'), Request::VALID_IN_ARRAY, Config::get('ALLOW_DEVICES'));
         $request->set('device_type', $device_type);
 
         // 検索条件作成
@@ -176,7 +177,7 @@ class BlogPluginsController extends AdminController
         $this->set('blog_plugin_attribute_color', BlogPluginsModel::getAttributeColor());
         $this->set('device_key_list', Config::get('DEVICE_FC2_KEY'));
         $this->set('device_type', $request->get('blog_plugin.device_type'));
-        $this->set('device_type_sp', Config::get('DEVICE_SP'));
+        $this->set('device_type_sp', (string)Config::get('DEVICE_SP'));
 
         // 編集対象のデータ取得
         if (!$blog_plugin = $blog_plugins_model->findByIdAndBlogId($id, $blog_id)) {

--- a/app/src/Web/Controller/Admin/BlogSettingsController.php
+++ b/app/src/Web/Controller/Admin/BlogSettingsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/BlogSettingsController.php
+++ b/app/src/Web/Controller/Admin/BlogSettingsController.php
@@ -74,7 +74,7 @@ class BlogSettingsController extends AdminController
     private function settingEdit(Request $request, $white_list, $action): string
     {
         $blog_settings_model = new BlogSettingsModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 初期表示時に編集データの取得&設定
         if (!$request->get('blog_setting') || !$request->isValidSig()) {

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -8,6 +8,7 @@ use Fc2blog\Model\BlogsModel;
 use Fc2blog\Model\BlogTemplatesModel;
 use Fc2blog\Model\Fc2TemplatesModel;
 use Fc2blog\Model\Model;
+use Fc2blog\Service\BlogService;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
 
@@ -28,7 +29,7 @@ class BlogTemplatesController extends AdminController
             $device_type = $request->get('device_type', 1);
         }
 
-        $blog = $this->getBlog($blog_id);
+        $blog = BlogService::getById($blog_id);
         $blogs_model = new BlogsModel();
         $this->set('template_ids', $blogs_model->getTemplateIds($blog));
 
@@ -282,7 +283,7 @@ class BlogTemplatesController extends AdminController
         $blog_id = $this->getBlogId($request);
 
         // 使用中のテンプレート判定
-        $blog = $this->getBlog($blog_id);
+        $blog = BlogService::getById($blog_id);
         $template_ids = BlogsModel::getTemplateIds($blog);
         if (in_array($id, $template_ids)) {
             $this->setErrorMessage(__('You can not delete a template in use'));

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 
@@ -55,7 +56,7 @@ class BlogTemplatesController extends AdminController
     public function fc2_index(Request $request): string
     {
         // デバイスタイプの設定
-        $device_type = $request->get('device_type', Config::get('DEVICE_PC'));
+        $device_type = $request->get('device_type', (string)Config::get('DEVICE_PC'));
         $request->set('device_type', $device_type);
 
         // 条件設定
@@ -91,7 +92,7 @@ class BlogTemplatesController extends AdminController
         }
 
         // デバイスタイプの設定
-        $device_type = $request->get('device_type', Config::get('DEVICE_PC'));
+        $device_type = $request->get('device_type', (string)Config::get('DEVICE_PC'));
         $request->set('device_type', $device_type);
 
         // テンプレート取得

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -10,7 +10,6 @@ use Fc2blog\Model\Fc2TemplatesModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Service\BlogService;
 use Fc2blog\Web\Request;
-use Fc2blog\Web\Session;
 
 class BlogTemplatesController extends AdminController
 {
@@ -214,7 +213,7 @@ class BlogTemplatesController extends AdminController
             $this->redirectBack($request, array('action' => 'index'));
         }
 
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // テンプレートの切り替え作業
             Model::load('Blogs')->switchTemplate($blog_template, $blog_id);
             $this->setInfoMessage(__('I switch the template'));
@@ -295,7 +294,7 @@ class BlogTemplatesController extends AdminController
             $this->redirect($request, array('action' => 'index'));
         }
 
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 削除処理
             $blog_templates_model->deleteByIdAndBlogId($id, $blog_id);
             $this->setInfoMessage(__('I removed the template'));

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -22,7 +22,7 @@ class BlogTemplatesController extends AdminController
      */
     public function index(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         if (App::isPC($request)) {
             $device_type = $request->get('device_type', 0);
         } else {
@@ -146,7 +146,7 @@ class BlogTemplatesController extends AdminController
         $white_list = ['title', 'html', 'css', 'device_type'];
         $errors['blog_template'] = $blog_templates_model->validate($request->get('blog_template'), $blog_template_data, $white_list);
         if (empty($errors['blog_template'])) {
-            $blog_template_data['blog_id'] = $this->getBlogId($request);
+            $blog_template_data['blog_id'] = $this->getBlogIdFromSession();
             if ($blog_templates_model->insert($blog_template_data)) {
                 $this->setInfoMessage(__('I created a template'));
                 $this->redirect($request, ['action' => 'index']);
@@ -169,7 +169,7 @@ class BlogTemplatesController extends AdminController
         $blog_templates_model = new BlogTemplatesModel();
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 初期表示時に編集データの取得&設定
         if (!$request->get('blog_template') || !$request->isValidSig()) {
@@ -206,7 +206,7 @@ class BlogTemplatesController extends AdminController
         $blog_templates_model = Model::load('BlogTemplates');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $blog_template = $blog_templates_model->findByIdAndBlogId($id, $blog_id);
         if (empty($blog_template)) {
@@ -258,7 +258,7 @@ class BlogTemplatesController extends AdminController
         $white_list = array('title', 'html', 'css', 'device_type');
         $errors['blog_template'] = $blog_templates_model->validate($blog_template, $blog_template_data, $white_list);
         if (empty($errors['blog_template'])) {
-            $blog_template_data['blog_id'] = $this->getBlogId($request);
+            $blog_template_data['blog_id'] = $this->getBlogIdFromSession();
             if ($blog_templates_model->insert($blog_template_data)) {
                 $this->setInfoMessage('「' . h($blog_template['title']) . '」' . __('I downloaded the template'));
                 $this->redirect($request, array('action' => 'index', 'device_type' => $device_type));
@@ -280,7 +280,7 @@ class BlogTemplatesController extends AdminController
         $blog_templates_model = Model::load('BlogTemplates');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 使用中のテンプレート判定
         $blog = BlogService::getById($blog_id);

--- a/app/src/Web/Controller/Admin/BlogsController.php
+++ b/app/src/Web/Controller/Admin/BlogsController.php
@@ -82,7 +82,7 @@ class BlogsController extends AdminController
     {
         $blogs_model = new BlogsModel();
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $this->set('open_status_list', BlogsModel::getOpenStatusList());
         $this->set('time_zone_list', BlogsModel::getTimezoneList());
         $this->set('ssl_enable_settings_list', BlogsModel::getSSLEnableSettingList());
@@ -156,7 +156,7 @@ class BlogsController extends AdminController
             return 'admin/blogs/delete.twig';
         }
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $user_id = $this->getUserId();
 
         // 削除するブログが存在するか？

--- a/app/src/Web/Controller/Admin/BlogsController.php
+++ b/app/src/Web/Controller/Admin/BlogsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -20,10 +20,10 @@ class CategoriesController extends AdminController
     {
         $categories_model = new CategoriesModel();
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->set('categories_model_order_list', $categories_model::getOrderList());
-        $this->set('categories', $categories_model->getList($this->getBlogId($request)));
+        $this->set('categories', $categories_model->getList($this->getBlogIdFromSession()));
 
         // 親カテゴリー一覧
         $options = $categories_model->getParentList($blog_id);
@@ -74,7 +74,7 @@ class CategoriesController extends AdminController
         $categories_model = new CategoriesModel();
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 親カテゴリー一覧
         $options = $categories_model->getParentList($blog_id, $id);
@@ -117,7 +117,7 @@ class CategoriesController extends AdminController
         $categories_model = Model::load('Categories');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         if (!Session::get('sig') || Session::get('sig') !== $request->get('sig')) {
             $request = new Request();
@@ -151,7 +151,7 @@ class CategoriesController extends AdminController
         /** @var CategoriesModel $categories_model */
         $categories_model = Model::load('Categories');
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $json = array('status' => 0);
 

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -6,7 +6,6 @@ use Fc2blog\Config;
 use Fc2blog\Model\CategoriesModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Web\Request;
-use Fc2blog\Web\Session;
 
 class CategoriesController extends AdminController
 {
@@ -82,7 +81,7 @@ class CategoriesController extends AdminController
         $this->set('categories_model_order_list', $categories_model::getOrderList());
 
         // 初期表示時に編集データの取得&設定
-        if (!$request->get('category') || !Session::get('sig') || Session::get('sig') !== $request->get('sig')) {
+        if (!$request->get('category') || !$request->isValidSig()) {
             if (!$category = $categories_model->findByIdAndBlogId($id, $blog_id)) {
                 $this->redirect($request, ['action' => 'create']);
             }
@@ -119,7 +118,7 @@ class CategoriesController extends AdminController
         $id = $request->get('id');
         $blog_id = $this->getBlogIdFromSession();
 
-        if (!Session::get('sig') || Session::get('sig') !== $request->get('sig')) {
+        if (!$request->isValidSig()) {
             $request = new Request();
             $this->redirect($request, array('action' => 'create'));
             return;

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -20,7 +20,7 @@ class CommentsController extends AdminController
     public function index(Request $request): string
     {
         $comments_model = new CommentsModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 検索条件
         $where = 'comments.blog_id=?';
@@ -137,7 +137,7 @@ class CommentsController extends AdminController
         $comments_model = Model::load('Comments');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 承認データの取得
         if (!$comment = $comments_model->findByIdAndBlogId($id, $blog_id)) {
@@ -176,7 +176,7 @@ class CommentsController extends AdminController
         $comments_model = Model::load('Comments');
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 承認データの取得
         if (!$comment = $comments_model->findByIdAndBlogId($id, $blog_id)) {
@@ -211,7 +211,7 @@ class CommentsController extends AdminController
         $comments_model = new CommentsModel();
 
         $comment_id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $this->setStatusDataList();
 
         // 返信用のコメント取得
@@ -274,7 +274,7 @@ class CommentsController extends AdminController
         $comments_model = new CommentsModel();
 
         $comment_id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->setStatusDataList();
 
@@ -328,7 +328,7 @@ class CommentsController extends AdminController
         }
 
         // 削除処理
-        if (Model::load('Comments')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogId($request))) {
+        if (Model::load('Comments')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
             $this->setInfoMessage(__('I removed the comment'));
         } else {
             $this->setErrorMessage(__('I failed to remove'));
@@ -359,7 +359,7 @@ class CommentsController extends AdminController
         $comments_model = new CommentsModel();
 
         // 既読処理
-        if ($comments_model->setReadByIdsAndBlogId($comment_id_list, $this->getBlogId($request))) {
+        if ($comments_model->setReadByIdsAndBlogId($comment_id_list, $this->getBlogIdFromSession())) {
             $this->setInfoMessage(__('I set already read the comment'));
         } else {
             $this->setErrorMessage(__('I failed to set read'));

--- a/app/src/Web/Controller/Admin/CommonController.php
+++ b/app/src/Web/Controller/Admin/CommonController.php
@@ -95,10 +95,9 @@ class CommonController extends AdminController
 
     /**
      * お知らせ一覧画面
-     * @param Request $request
      * @return string
      */
-    public function notice(Request $request): string
+    public function notice(/*Request $request*/): string
     {
         $blog_id = $this->getBlogIdFromSession();
 
@@ -131,7 +130,7 @@ class CommonController extends AdminController
                 $this->set('temp_dir', Config::get('TEMP_DIR'));
                 $this->set('www_upload_dir', Config::get('WWW_UPLOAD_DIR'));
                 $this->set('is_db_connect_lib', defined('DB_CONNECT_LIB'));
-            /** @noinspection PhpRedundantOptionalArgumentInspection */
+                /** @noinspection PhpRedundantOptionalArgumentInspection */
                 $this->set('random_string', App::genRandomStringAlphaNum(32));
 
                 $this->set('DB_HOST', DB_HOST);

--- a/app/src/Web/Controller/Admin/CommonController.php
+++ b/app/src/Web/Controller/Admin/CommonController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 
@@ -55,7 +56,7 @@ class CommonController extends AdminController
                 $device_type = Config::get('DEVICE_SP');
                 break;
             default:
-                Cookie::set($request, 'device', null);
+                Cookie::set($request, 'device', Config::get('DEVICE_PC'));
                 $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index'));
         }
 

--- a/app/src/Web/Controller/Admin/CommonController.php
+++ b/app/src/Web/Controller/Admin/CommonController.php
@@ -70,7 +70,7 @@ class CommonController extends AdminController
     public function index(Request $request)
     {
         // 設定読み込みをしてリダイレクト
-        if (is_string($blog_id = $this->getBlogId($request))) {
+        if (is_string($blog_id = $this->getBlogIdFromSession())) {
             $blog_settings = new BlogSettingsModel();
             $setting = $blog_settings->findByBlogId($blog_id);
         } else {
@@ -99,7 +99,7 @@ class CommonController extends AdminController
      */
     public function notice(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $comments_model = new CommentsModel();
         $this->set('unread_count', $comments_model->getUnreadCount($blog_id));

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -25,7 +25,7 @@ class EntriesController extends AdminController
     public function index(Request $request): string
     {
         $entries_model = new EntriesModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 検索条件
         $where = 'entries.blog_id=?';
@@ -106,8 +106,8 @@ class EntriesController extends AdminController
         $categories_model = new CategoriesModel();
         $tags_model = new TagsModel();
         $entries_model = new EntriesModel();
-        $this->set('category_list_w', ['' => __('Category name')] + $categories_model->getSearchList($this->getBlogId($request)));
-        $this->set('tag_list_w', ['' => _('Tag name')] + $tags_model->getSearchList($this->getBlogId($request)));
+        $this->set('category_list_w', ['' => __('Category name')] + $categories_model->getSearchList($this->getBlogIdFromSession()));
+        $this->set('tag_list_w', ['' => _('Tag name')] + $tags_model->getSearchList($this->getBlogIdFromSession()));
         $this->set('open_status_list_w', ['' => __('Public state')] + $entries_model::getOpenStatusList());
         $this->set('open_status_list', $entries_model::getOpenStatusList());
         return "admin/entries/index.twig";
@@ -125,7 +125,7 @@ class EntriesController extends AdminController
         $entry_tags_model = new EntryTagsModel();
         $tags_model = new TagsModel();
         $categories_model = new CategoriesModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // data load
         if (is_null($request->get('entry_tags'))) {
@@ -153,7 +153,7 @@ class EntriesController extends AdminController
         $this->set('entry_open_status_limit', Config::get('ENTRY.OPEN_STATUS.LIMIT'));
         $this->set('entry_open_status_reservation', Config::get('ENTRY.OPEN_STATUS.RESERVATION'));
         $this->set('domain_user', Config::get('DOMAIN_USER'));
-        $this->set('user_url', App::userURL($request, ['controller' => 'Entries', 'action' => 'preview', 'blog_id' => $this->getBlogId($request)], false, true));
+        $this->set('user_url', App::userURL($request, ['controller' => 'Entries', 'action' => 'preview', 'blog_id' => $this->getBlogIdFromSession()], false, true));
 
         // 初期表示時
         if (!$request->get('entry') || !$request->isValidSig()) {
@@ -197,7 +197,7 @@ class EntriesController extends AdminController
         $tags_model = new TagsModel();
         $categories_model = new CategoriesModel();
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
         $id = $request->get('id');
 
         if (!$entry = $entries_model->findByIdAndBlogId($id, $blog_id)) {
@@ -233,7 +233,7 @@ class EntriesController extends AdminController
             $this->set('entry_open_status_limit', Config::get('ENTRY.OPEN_STATUS.LIMIT'));
             $this->set('entry_open_status_reservation', Config::get('ENTRY.OPEN_STATUS.RESERVATION'));
             $this->set('domain_user', Config::get('DOMAIN_USER'));
-            $this->set('user_url', App::userURL($request, ['controller' => 'Entries', 'action' => 'preview', 'blog_id' => $this->getBlogId($request)], false, true));
+            $this->set('user_url', App::userURL($request, ['controller' => 'Entries', 'action' => 'preview', 'blog_id' => $this->getBlogIdFromSession()], false, true));
 
             return "admin/entries/edit.twig";
         }
@@ -277,7 +277,7 @@ class EntriesController extends AdminController
         $this->set('entry_open_status_limit', Config::get('ENTRY.OPEN_STATUS.LIMIT'));
         $this->set('entry_open_status_reservation', Config::get('ENTRY.OPEN_STATUS.RESERVATION'));
         $this->set('domain_user', Config::get('DOMAIN_USER'));
-        $this->set('user_url', App::userURL($request, ['controller' => 'Entries', 'action' => 'preview', 'blog_id' => $this->getBlogId($request)], false, true));
+        $this->set('user_url', App::userURL($request, ['controller' => 'Entries', 'action' => 'preview', 'blog_id' => $this->getBlogIdFromSession()], false, true));
 
         // エラー情報の設定
         $this->setErrorMessage(__('Input error exists'));
@@ -293,7 +293,7 @@ class EntriesController extends AdminController
     {
         if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
             // 削除処理
-            if (Model::load('Entries')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogId($request)))
+            if (Model::load('Entries')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession()))
                 $this->setInfoMessage(__('I removed the entry'));
         }
         $this->redirect($request, array('action' => 'index'));
@@ -312,7 +312,7 @@ class EntriesController extends AdminController
         }
 
         $files_model = new FilesModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // 検索条件
         $where = 'blog_id=?';

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 
@@ -144,7 +145,7 @@ class EntriesController extends AdminController
         $this->set('entry_categories', $request->get('entry_categories', array('category_id' => array())));
         $this->set('categories', $categories_model->getList($blog_id));
         // 以下はSPテンプレ用で追加
-        $now = strtotime($request->get('entry.posted_at'));
+        $now = strtotime($request->get('entry.posted_at', ""));
         $now = $now === false ? time() : $now;
         $date_list = explode('/', date('Y/m/d/H/i/s', $now));
         $this->set('entry_date_list', $date_list);

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -12,7 +12,6 @@ use Fc2blog\Model\FilesModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Model\TagsModel;
 use Fc2blog\Web\Request;
-use Fc2blog\Web\Session;
 
 class EntriesController extends AdminController
 {
@@ -291,7 +290,7 @@ class EntriesController extends AdminController
      */
     public function delete(Request $request)
     {
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 削除処理
             if (Model::load('Entries')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession()))
                 $this->setInfoMessage(__('I removed the entry'));

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -7,7 +7,6 @@ use Fc2blog\Config;
 use Fc2blog\Model\FilesModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Web\Request;
-use Fc2blog\Web\Session;
 
 class FilesController extends AdminController
 {
@@ -269,7 +268,7 @@ class FilesController extends AdminController
      */
     public function delete(Request $request)
     {
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 削除処理
             if (Model::load('Files')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
                 $this->setInfoMessage(__('I removed the file'));

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -26,7 +26,7 @@ class FilesController extends AdminController
 
         $files_model = new FilesModel();
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->set('file_default_limit', Config::get('FILE.DEFAULT_LIMIT'));
         $this->set('page_list_file', App::getPageList($request, 'FILE'));
@@ -88,7 +88,7 @@ class FilesController extends AdminController
     public function upload(Request $request): string
     {
         $files_model = new FilesModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->set('file_max_size', Config::get('FILE.MAX_SIZE'));
         $this->set('page_limit_file', App::getPageLimit($request, 'FILE'));
@@ -192,7 +192,7 @@ class FilesController extends AdminController
     {
         $files_model = new FilesModel();
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->set('file_max_size', Config::get('FILE.MAX_SIZE'));
 
@@ -271,7 +271,7 @@ class FilesController extends AdminController
     {
         if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
             // 削除処理
-            if (Model::load('Files')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogId($request))) {
+            if (Model::load('Files')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
                 $this->setInfoMessage(__('I removed the file'));
             } else {
                 $this->setErrorMessage(__('I failed to remove'));
@@ -300,7 +300,7 @@ class FilesController extends AdminController
 
         // 削除処理
         $json = array('status' => 0);
-        if (!Model::load('Files')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogId($request))) {
+        if (!Model::load('Files')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
             $json = array('status' => 1);
         }
 
@@ -322,7 +322,7 @@ class FilesController extends AdminController
         }
 
         $files_model = new FilesModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         // アップロード時処理
         if ($request->file('file')) {

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/SessionController.php
+++ b/app/src/Web/Controller/Admin/SessionController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/SystemUpdateController.php
+++ b/app/src/Web/Controller/Admin/SystemUpdateController.php
@@ -26,7 +26,6 @@ class SystemUpdateController extends AdminController
     {
         // TODO unit test
 
-        // check sig
         if (!$request->isValidSig()) {
             $this->setWarnMessage(__("Request failed: invalid sig, please retry."));
             $this->redirect($request, Html::url($request, ['controller' => 'system_update', 'action' => 'index']));

--- a/app/src/Web/Controller/Admin/TagsController.php
+++ b/app/src/Web/Controller/Admin/TagsController.php
@@ -6,7 +6,6 @@ use Fc2blog\Config;
 use Fc2blog\Model\Model;
 use Fc2blog\Model\TagsModel;
 use Fc2blog\Web\Request;
-use Fc2blog\Web\Session;
 
 class TagsController extends AdminController
 {
@@ -132,7 +131,7 @@ class TagsController extends AdminController
      */
     public function delete(Request $request)
     {
-        if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
+        if ($request->isValidSig()) {
             // 削除処理
             if (Model::load('Tags')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
                 $this->setInfoMessage(__('I removed the tag'));

--- a/app/src/Web/Controller/Admin/TagsController.php
+++ b/app/src/Web/Controller/Admin/TagsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Admin/TagsController.php
+++ b/app/src/Web/Controller/Admin/TagsController.php
@@ -19,7 +19,7 @@ class TagsController extends AdminController
     public function index(Request $request): string
     {
         $tags_model = new TagsModel();
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         $this->set('tag_limit_list', Config::get('TAG.LIMIT_LIST'));
         $this->set('tag_default_limit', Config::get('TAG.DEFAULT_LIMIT'));
@@ -84,7 +84,7 @@ class TagsController extends AdminController
         $tags_model = new TagsModel();
 
         $id = $request->get('id');
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $this->getBlogIdFromSession();
 
         if (!$tag = $tags_model->findByIdAndBlogId($id, $blog_id)) {
             $this->redirect($request, ['action' => 'index']);
@@ -134,7 +134,7 @@ class TagsController extends AdminController
     {
         if (Session::get('sig') && Session::get('sig') === $request->get('sig')) {
             // 削除処理
-            if (Model::load('Tags')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogId($request))) {
+            if (Model::load('Tags')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
                 $this->setInfoMessage(__('I removed the tag'));
             } else {
                 $this->setErrorMessage(__('I failed to remove'));

--- a/app/src/Web/Controller/Admin/UsersController.php
+++ b/app/src/Web/Controller/Admin/UsersController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\Admin;
 

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -7,6 +7,7 @@ use Fc2blog\App;
 use Fc2blog\Config;
 use Fc2blog\Exception\RedirectExit;
 use Fc2blog\Model\BlogsModel;
+use Fc2blog\Service\BlogService;
 use Fc2blog\Service\TwigService;
 use Fc2blog\Util\Log;
 use Fc2blog\Web\Controller\Admin\AdminController;
@@ -249,8 +250,8 @@ abstract class Controller
                 ]
             ];
             // リクエストからログインblogを特定し、保存
-            if ($this->getBlog($this->getBlogId($request)) !== false && is_string($this->getBlogId($request))) {
-                $data['blog'] = $this->getBlog($this->getBlogId($request));
+            if (BlogService::getById($this->getBlogId($request)) !== false && is_string($this->getBlogId($request))) {
+                $data['blog'] = BlogService::getById($this->getBlogId($request));
                 $data['blog']['url'] = BlogsModel::getFullHostUrlByBlogId($this->getBlogId($request), Config::get('DOMAIN_USER')) . "/" . $this->getBlogId($request) . "/";
             }
         } else {
@@ -478,17 +479,6 @@ abstract class Controller
             throw new LogicException("the method is only for testing.");
         }
         return $this->data;
-    }
-
-    /**
-     * blog_idからブログ情報を取得
-     * @param $blog_id
-     * @return array|false
-     * @deprecated TODO Modelに移動するべき
-     */
-    public function getBlog($blog_id)
-    {
-        return (new BlogsModel())->findById($blog_id);
     }
 
     /**

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -99,6 +99,13 @@ abstract class Controller
             }
         }
 
+        if ( # show DEBUG MODE warnings.
+            strpos("text/html", $this->getContentType()) > 0 &&
+            defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY === "1"
+        ) {
+            echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><hr>";
+        }
+
         echo $this->output;
     }
 
@@ -154,6 +161,11 @@ abstract class Controller
     public function setContentType(string $mime_type = 'text/html; charset=UTF-8'): void
     {
         $this->responseHeaders['Content-Type'] = $mime_type;
+    }
+
+    public function getContentType(): string
+    {
+        return $this->responseHeaders['Content-Type'];
     }
 
     /**

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -254,7 +254,7 @@ abstract class Controller
                 'sig' => Session::get('sig'),
                 'lang' => $request->lang,
                 'debug' => Config::get('APP_DEBUG') != 0,
-                'preview_active_blog_url' => App::userURL($request, ['controller' => 'entries', 'action' => 'index', 'blog_id' => $this->getBlogId($request)]), // 代用できそう
+                'preview_active_blog_url' => App::userURL($request, ['controller' => 'entries', 'action' => 'index', 'blog_id' => $this->getBlogIdFromSession()]), // 代用できそう
                 'is_register_able' => (Config::get('USER.REGIST_SETTING.FREE') == Config::get('USER.REGIST_STATUS')), // TODO 意図する解釈確認
                 'active_menu' => App::getActiveMenu($request),
                 'isLogin' => $this->isLogin(),
@@ -274,9 +274,9 @@ abstract class Controller
                 ]
             ];
             // リクエストからログインblogを特定し、保存
-            if (BlogService::getById($this->getBlogId($request)) !== false && is_string($this->getBlogId($request))) {
-                $data['blog'] = BlogService::getById($this->getBlogId($request));
-                $data['blog']['url'] = BlogsModel::getFullHostUrlByBlogId($this->getBlogId($request), Config::get('DOMAIN_USER')) . "/" . $this->getBlogId($request) . "/";
+            if (BlogService::getById($this->getBlogIdFromSession()) !== false && is_string($this->getBlogIdFromSession())) {
+                $data['blog'] = BlogService::getById($this->getBlogIdFromSession());
+                $data['blog']['url'] = BlogsModel::getFullHostUrlByBlogId($this->getBlogIdFromSession(), Config::get('DOMAIN_USER')) . "/" . $this->getBlogIdFromSession() . "/";
             }
         } else {
             // User系画面のデータ生成

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -482,20 +482,6 @@ abstract class Controller
     }
 
     /**
-     * tokenチェック
-     * @param Request $request
-     * @param string $name
-     * @return string|null
-     * TODO captchaでしかつかっていないので、名前をかえるべき
-     */
-    protected function tokenValidate(Request $request, string $name = 'token'): ?string
-    {
-        $value = $request->get($name, '');
-        $value = mb_convert_kana($value, 'n');
-        return Session::remove($name) == $value ? null : __('Token authentication is invalid');
-    }
-
-    /**
      * ブログの`http(s)://FQDN(:port)`を生成する
      * @return string
      */

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -271,13 +271,6 @@ abstract class Controller
         }
     }
 
-    // 存在しないアクションはエラーとして404へ
-    // TODO 「アクションではない」メソッドがたたけないようにする。アクション以外を追い出すかシグネチャを見るか。
-    public function __call($name, $arguments): string
-    {
-        return $this->error404();
-    }
-
     // 404 NotFound Action
     public function error404(): string
     {

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -492,21 +492,6 @@ abstract class Controller
     }
 
     /**
-     * token発行
-     * @param null $key
-     * @param string $name
-     * TODO captchaでしかつかっていないので、名前をかえるべき
-     */
-    protected function setToken($key = null, string $name = 'token'): void
-    {
-        if ($key === null) {
-            // 適当な値をトークンに設定
-            $key = App::genRandomStringAlphaNum();
-        }
-        Session::set($name, $key);
-    }
-
-    /**
      * tokenチェック
      * @param Request $request
      * @param string $name

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -115,7 +115,7 @@ abstract class Controller
         # ORIGINを検証
         if (
             isset($request->server['HTTP_ORIGIN']) &&
-            $request->server['HTTP_ORIGIN'] !== Controller::getHostUrl()
+            $request->server['HTTP_ORIGIN'] !== $request->getHostUrl()
         ) {
             return true;
         }
@@ -353,17 +353,5 @@ abstract class Controller
             throw new LogicException("the method is only for testing.");
         }
         return $this->data;
-    }
-
-    /**
-     * ブログの`http(s)://FQDN(:port)`を生成する
-     * @return string
-     */
-    static public function getHostUrl(): string
-    {
-        $schema = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === "on") ? 'https:' : 'http:';
-        $domain = Config::get("DOMAIN");
-        $port = ($schema === "https:") ? Config::get("HTTPS_PORT_STR") : Config::get("HTTP_PORT_STR");
-        return $schema . "//" . $domain . $port;
     }
 }

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -133,6 +133,30 @@ abstract class Controller
     }
 
     /**
+     * @param string $key
+     * @return mixed
+     */
+    public function get(string $key)
+    {
+        return $this->data[$key];
+    }
+
+    public function getStatusCode(): int
+    {
+        return (int)$this->data['http_status_code'];
+    }
+
+    public function setStatusCode(int $code = 200): void
+    {
+        $this->data['http_status_code'] = $code;
+    }
+
+    public function setContentType(string $mime_type = 'text/html; charset=UTF-8'): void
+    {
+        $this->responseHeaders['Content-Type'] = $mime_type;
+    }
+
+    /**
      * リダイレクト
      * MEMO: Blog idが特定できないときの強制的なSchemaがさだまらない
      * TODO: この時点でリダイレクトせず、 emit時にヘッダー送信する形にリファクタリングすべき
@@ -292,36 +316,12 @@ abstract class Controller
         return 'user/common/error400.twig';
     }
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
-    public function get(string $key)
-    {
-        return $this->data[$key];
-    }
-
     public function getOutput(): string
     {
         if (!defined("THIS_IS_TEST")) {
             throw new LogicException("the method is only for testing.");
         }
         return $this->output;
-    }
-
-    public function getStatusCode(): int
-    {
-        return (int)$this->data['http_status_code'];
-    }
-
-    public function setStatusCode(int $code = 200): void
-    {
-        $this->data['http_status_code'] = $code;
-    }
-
-    public function setContentType(string $mime_type = 'text/html; charset=UTF-8'): void
-    {
-        $this->responseHeaders['Content-Type'] = $mime_type;
     }
 
     public function getResolvedMethod(): string

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -492,16 +492,6 @@ abstract class Controller
     }
 
     /**
-     * デバイスタイプを取得する
-     * @return int
-     * @deprecated TODO requestに置換できる
-     */
-    protected function getDeviceType(): int
-    {
-        return $this->request->deviceType;
-    }
-
-    /**
      * token発行
      * @param null $key
      * @param string $name

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -11,7 +11,7 @@ use Fc2blog\Service\BlogService;
 use Fc2blog\Service\TwigService;
 use Fc2blog\Util\Log;
 use Fc2blog\Web\Controller\Admin\AdminController;
-use Fc2blog\Web\Fc2BlogTemplate;
+use Fc2blog\Web\Controller\User\UserController;
 use Fc2blog\Web\Html;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
@@ -79,7 +79,7 @@ abstract class Controller
         // テンプレートファイル拡張子で、PHPテンプレートとTwigテンプレートを切り分ける
         if (preg_match("/\.twig\z/u", $template_path)) {
             $this->output = $this->renderByTwig($this->request, $template_path);
-        } elseif ($this->layout === 'fc2_template.php') {
+        } elseif ($this->layout === 'fc2_template.php' && $this instanceof UserController) {
             $this->output = $this->renderByFc2Template($this->request, $template_path);
         }
         // $this->layout === '' の場合は、空ボディか、$this->outputにすでになにか入れられているという想定
@@ -269,34 +269,6 @@ abstract class Controller
         } catch (Error $e) {
             throw new RuntimeException("Twig error: {$e->getMessage()} {$e->getFile()}:{$e->getTemplateLine()}");
         }
-    }
-
-    /**
-     * FC2タグを用いたユーザーテンプレート（PHP）でHTMLをレンダリング
-     * @param Request $request
-     * @param string $template_file_path
-     * @return string
-     * TODO User系のみで用いられるので、後日UserControllerへ移動
-     */
-    private function renderByFc2Template(Request $request, string $template_file_path): string
-    {
-        if (is_null($template_file_path)) {
-            throw new InvalidArgumentException("undefined template");
-        }
-        if (!is_file($template_file_path)) {
-            throw new InvalidArgumentException("missing template");
-        }
-
-        $this->data = Fc2BlogTemplate::preprocessingData($request, $this->data);
-
-        // 設定されているdataをローカルスコープに展開
-        extract($this->data);
-
-        // テンプレートをレンダリングして返す
-        ob_start();
-        /** @noinspection PhpIncludeInspection */
-        include($template_file_path);
-        return ob_get_clean();
     }
 
     // 存在しないアクションはエラーとして404へ

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -11,7 +11,7 @@ use Fc2blog\Service\BlogService;
 use Fc2blog\Service\TwigService;
 use Fc2blog\Util\Log;
 use Fc2blog\Web\Controller\Admin\AdminController;
-use Fc2blog\Web\Controller\User\UserController;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Html;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
@@ -272,104 +272,6 @@ abstract class Controller
     }
 
     /**
-     * fc2blog形式のPHP Viewテンプレート内で利用する各種データを生成・変換
-     * @param Request $request
-     * @param array $data
-     * @return array
-     * TODO アクションではないので、なんらか別クラスへ切り出すべき
-     */
-    static public function preprocessingDataForFc2Template(Request $request, array $data): array
-    {
-        $data['request'] = $request;
-
-        // FC2のテンプレート用にデータを置き換える
-        if (!empty($data['entry'])) {
-            $data['entries'] = [$data['entry']];
-        }
-        if (!empty($data['entries'])) {
-            foreach ($data['entries'] as $key => $value) {
-                // topentry系変数のデータ設定
-                $data['entries'][$key]['title_w_img'] = $value['title'];
-                $data['entries'][$key]['title'] = strip_tags($value['title']);
-                $data['entries'][$key]['link'] = App::userURL($request, ['controller' => 'Entries', 'action' => 'view', 'blog_id' => $value['blog_id'], 'id' => $value['id']]);
-
-                [
-                    $data['entries'][$key]['year'],
-                    $data['entries'][$key]['month'],
-                    $data['entries'][$key]['day'],
-                    $data['entries'][$key]['hour'],
-                    $data['entries'][$key]['minute'],
-                    $data['entries'][$key]['second'],
-                    $data['entries'][$key]['youbi'],
-                    $data['entries'][$key]['month_short']
-                ] = explode('/', date('Y/m/d/H/i/s/D/M', strtotime($value['posted_at'])));
-                $data['entries'][$key]['wayoubi'] = __($data['entries'][$key]['youbi']);
-
-                // 自動改行処理
-                if ($value['auto_linefeed'] == Config::get('ENTRY.AUTO_LINEFEED.USE')) {
-                    $data['entries'][$key]['body'] = nl2br($value['body']);
-                    $data['entries'][$key]['extend'] = nl2br($value['extend']);
-                }
-
-                // topentry_enc_* 系タグの生成
-                $data['entries'][$key]['enc_title'] = urlencode($data['entries'][$key]['title']);
-                $data['entries'][$key]['enc_utftitle'] = urlencode($data['entries'][$key]['title']);
-                $data['entries'][$key]['enc_link'] = urlencode($data['entries'][$key]['link']);
-            }
-        }
-
-        // コメント一覧の情報
-        if (!empty($data['comments'])) {
-            foreach ($data['comments'] as $key => $value) {
-                $data['comments'][$key]['edit_link'] = Html::url($request, ['controller' => 'Entries', 'action' => 'comment_edit', 'blog_id' => $value['blog_id'], 'id' => $value['id']]);
-
-                [
-                    $data['comments'][$key]['year'],
-                    $data['comments'][$key]['month'],
-                    $data['comments'][$key]['day'],
-                    $data['comments'][$key]['hour'],
-                    $data['comments'][$key]['minute'],
-                    $data['comments'][$key]['second'],
-                    $data['comments'][$key]['youbi']
-                ] = explode('/', date('Y/m/d/H/i/s/D', strtotime($value['updated_at'])));
-                $data['comments'][$key]['wayoubi'] = __($data['comments'][$key]['youbi']);
-                $data['comments'][$key]['body'] = $value['body']; // TODO nl2brされていないのは正しいのか？
-
-                $value['reply_updated_at'] = $value['reply_updated_at'] ?? ""; // reply_updated_at is nullable
-                $reply_updated_at = strtotime($value['reply_updated_at']) ?: 0;
-                [
-                    $data['comments'][$key]['reply_year'],
-                    $data['comments'][$key]['reply_month'],
-                    $data['comments'][$key]['reply_day'],
-                    $data['comments'][$key]['reply_hour'],
-                    $data['comments'][$key]['reply_minute'],
-                    $data['comments'][$key]['reply_second'],
-                    $data['comments'][$key]['reply_youbi']
-                ] = explode('/', date('Y/m/d/H/i/s/D', $reply_updated_at));
-                $data['comments'][$key]['reply_wayoubi'] = __($data['comments'][$key]['reply_youbi']);
-                $data['comments'][$key]['reply_body'] = nl2br((string)$value['reply_body']);
-            }
-        }
-
-        // FC2用のどこでも有効な単変数
-        $data['blog_id'] = UserController::getBlogId($request); // TODO User系でしかこのメソッドは呼ばれないはずなので
-        if ($data['blog_id'] !== Config::get('DEFAULT_BLOG_ID')) {
-            $data['url'] = '/' . $data['blog']['id'] . '/';
-        } else {
-            // シングルテナントモード、DEFAULT_BLOG_IDとBlogIdが一致するなら、Pathを省略する
-            $data['url'] = '/';
-        }
-
-        // 年月日系
-        $data['now_date'] = (isset($data['date_area']) && $data['date_area']) ? $data['now_date'] : date('Y-m-d');
-        $data['now_month_date'] = date('Y-m-1', strtotime($data['now_date']));
-        $data['prev_month_date'] = date('Y-m-1', strtotime($data['now_month_date'] . ' -1 month'));
-        $data['next_month_date'] = date('Y-m-1', strtotime($data['now_month_date'] . ' +1 month'));
-
-        return $data;
-    }
-
-    /**
      * FC2タグを用いたユーザーテンプレート（PHP）でHTMLをレンダリング
      * @param Request $request
      * @param string $template_file_path
@@ -385,9 +287,9 @@ abstract class Controller
             throw new InvalidArgumentException("missing template");
         }
 
-        $this->data = static::preprocessingDataForFc2Template($request, $this->data);
+        $this->data = Fc2BlogTemplate::preprocessingData($request, $this->data);
 
-        // 設定されているdataを展開
+        // 設定されているdataをローカルスコープに展開
         extract($this->data);
 
         // テンプレートをレンダリングして返す

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -308,21 +308,21 @@ abstract class Controller
     }
 
     // 404 NotFound Action
-    public function error404(): string
+    protected function error404(): string
     {
         $this->setStatusCode(404);
         return 'user/common/error404.twig';
     }
 
     // 403 Forbidden
-    public function error403(): string
+    protected function error403(): string
     {
         $this->setStatusCode(403);
         return 'user/common/error403.twig';
     }
 
     // 400 BadRequest
-    public function error400(): string
+    protected function error400(): string
     {
         $this->setStatusCode(400);
         return 'user/common/error400.twig';

--- a/app/src/Web/Controller/User/CommonController.php
+++ b/app/src/Web/Controller/User/CommonController.php
@@ -51,11 +51,11 @@ class CommonController extends UserController
                 break;
             default:
                 Cookie::set($request, 'device', Config::get('DEVICE_PC'));
-                $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $this->getBlogId($request)));
+                $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $request->getBlogId()));
         }
 
         Cookie::set($request, 'device', $device_type);
-        $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $this->getBlogId($request)));
+        $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $request->getBlogId()));
     }
 
     const CAPTCHA_TOKEN_KEY_NAME = 'token';

--- a/app/src/Web/Controller/User/CommonController.php
+++ b/app/src/Web/Controller/User/CommonController.php
@@ -10,6 +10,7 @@ use Fc2blog\Lib\ThumbnailImageMaker;
 use Fc2blog\Util\Log;
 use Fc2blog\Web\Cookie;
 use Fc2blog\Web\Request;
+use Fc2blog\Web\Session;
 use RuntimeException;
 
 class CommonController extends UserController
@@ -74,7 +75,8 @@ class CommonController extends UserController
                 throw new RuntimeException("random_int thrown exception {$e->getMessage()}");
             }
         }
-        $this->setToken($key);    // トークン設定
+        Session::set('token', $key); // トークン設定
+
         // captchaの日本語モード判定
         // Cookieでlangがja以外は英語モード
         // Cookieに指定がなければ、Accept Languageヘッダーを参照し、一番がjaでなければ英語モード

--- a/app/src/Web/Controller/User/CommonController.php
+++ b/app/src/Web/Controller/User/CommonController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Fc2blog\Web\Controller\User;
 
@@ -38,7 +39,7 @@ class CommonController extends UserController
      */
     public function device_change(Request $request)
     {
-        // 言語の設定
+        // デバイスの設定
         $device_type = 0;
         $device = $request->get('device');
         switch ($device) {
@@ -49,7 +50,7 @@ class CommonController extends UserController
                 $device_type = Config::get('DEVICE_SP');
                 break;
             default:
-                Cookie::set($request, 'device', null);
+                Cookie::set($request, 'device', Config::get('DEVICE_PC'));
                 $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $this->getBlogId($request)));
         }
 

--- a/app/src/Web/Controller/User/CommonController.php
+++ b/app/src/Web/Controller/User/CommonController.php
@@ -114,7 +114,7 @@ class CommonController extends UserController
      * @param Request $request
      * @return string
      */
-    public function thumbnail(Request $request)
+    public function thumbnail(Request $request): string
     {
         $blog_id = $request->get('blog_id');
         $id = $request->get('id');

--- a/app/src/Web/Controller/User/CommonController.php
+++ b/app/src/Web/Controller/User/CommonController.php
@@ -57,6 +57,7 @@ class CommonController extends UserController
         $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $this->getBlogId($request)));
     }
 
+    const CAPTCHA_TOKEN_KEY_NAME = 'token';
     /**
      * 画像認証
      * @param Request $request
@@ -75,7 +76,7 @@ class CommonController extends UserController
                 throw new RuntimeException("random_int thrown exception {$e->getMessage()}");
             }
         }
-        Session::set('token', $key); // トークン設定
+        Session::set(self::CAPTCHA_TOKEN_KEY_NAME, $key); // トークン設定
 
         // captchaの日本語モード判定
         // Cookieでlangがja以外は英語モード
@@ -94,6 +95,18 @@ class CommonController extends UserController
         } catch (Exception $e) {
             throw new RuntimeException("drawNumber failed. {$e->getMessage()} {$e->getFile()}:{$e->getLine()}");
         }
+    }
+
+    /**
+     * Captcha token有効性チェック
+     * @param Request $request
+     * @return bool
+     */
+    public static function isValidCaptcha(Request $request): bool
+    {
+        $value = $request->get(CommonController::CAPTCHA_TOKEN_KEY_NAME, '');
+        $value = mb_convert_kana($value, 'n');
+        return (string)Session::remove(CommonController::CAPTCHA_TOKEN_KEY_NAME) === $value;
     }
 
     /**

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -34,7 +34,7 @@ class EntriesController extends UserController
         parent::beforeFilter($request);
 
         // ブログID指定があるかチェック
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         if (!$blog_id) {
             Log::notice("missing blog_id parameter. redirect to top.");
             $this->redirect($request, ['controller' => 'Blogs', 'action' => 'index']);
@@ -88,7 +88,7 @@ class EntriesController extends UserController
      */
     public function index(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         if (!$blog_id) {
             Log::notice("missing blog_id parameter. redirect to top. blog_id: {$blog_id}");
             $this->redirect($request, ['controller' => 'Blogs', 'action' => 'index']);
@@ -102,7 +102,7 @@ class EntriesController extends UserController
         $areas = $request->get('page') ? [] : ['index_area'];
         $this->setEntriesData($request, $options, $areas);
 
-        return $this->getFc2TemplatePath($this->getBlogId($request));
+        return $this->getFc2TemplatePath($request->getBlogId());
     }
 
     /**
@@ -113,7 +113,7 @@ class EntriesController extends UserController
     public function search(Request $request): string
     {
         $where = 'blog_id=?';
-        $params = array($this->getBlogId($request));
+        $params = array($request->getBlogId());
 
         // 検索ワード取得
         if ($keyword = $request->get('q')) {
@@ -129,7 +129,7 @@ class EntriesController extends UserController
             'params' => $params,
         );
         $this->setEntriesData($request, $options, array('search_area'));
-        return $this->getFc2TemplatePath($this->getBlogId($request));
+        return $this->getFc2TemplatePath($request->getBlogId());
     }
 
     /**
@@ -139,7 +139,7 @@ class EntriesController extends UserController
      */
     public function category(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $category_id = $request->get('cat');
 
         // カテゴリー名取得
@@ -163,7 +163,7 @@ class EntriesController extends UserController
             'order' => 'entries.posted_at ' . $order . ', entries.id ' . $order,
         );
         $this->setEntriesData($request, $options, array('category_area'));
-        return $this->getFc2TemplatePath($this->getBlogId($request));
+        return $this->getFc2TemplatePath($request->getBlogId());
     }
 
     /**
@@ -174,7 +174,7 @@ class EntriesController extends UserController
     public function tag(Request $request): string
     {
         // タグ検索
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $tag_name = $request->get('tag');
 
         $tag = Model::load('Tags')->findByNameAndBlogId($tag_name, $blog_id);
@@ -196,7 +196,7 @@ class EntriesController extends UserController
             'params' => $params,
         );
         $this->setEntriesData($request, $options, array('tag_area'));
-        return $this->getFc2TemplatePath($this->getBlogId($request));
+        return $this->getFc2TemplatePath($request->getBlogId());
     }
 
     /**
@@ -213,7 +213,7 @@ class EntriesController extends UserController
 
         // 記事一覧データ設定
         $where = 'blog_id=? AND ?<=posted_at AND posted_at<=?';
-        $params = array($this->getBlogId($request), $start, $end);
+        $params = array($request->getBlogId(), $start, $end);
 
         $options = array(
             'where' => $where,
@@ -221,7 +221,7 @@ class EntriesController extends UserController
         );
         $this->setEntriesData($request, $options, array('date_area'));
         $this->set('now_date', date('Y-m-d', strtotime($start)));
-        return $this->getFc2TemplatePath($this->getBlogId($request));
+        return $this->getFc2TemplatePath($request->getBlogId());
     }
 
     /**
@@ -239,11 +239,11 @@ class EntriesController extends UserController
                 'SUBSTRING(body, 1, 20) as body'
             ),
             'where' => 'blog_id=?',
-            'params' => array($this->getBlogId($request)),
+            'params' => array($request->getBlogId()),
         );
         $this->setEntriesData($request, $options, array('titlelist_area'));
         $this->set('sub_title', __("List of articles"));
-        return $this->getFc2TemplatePath($this->getBlogId($request));
+        return $this->getFc2TemplatePath($request->getBlogId());
     }
 
     /**
@@ -259,7 +259,7 @@ class EntriesController extends UserController
         }
 
         // preview処理用
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // 投稿者のブログIDチェック
         if ($blog_id != $this->getAdminBlogId() && !Model::load('Blogs')->isUserHaveBlogId($this->getAdminUserId(), $blog_id)) {
@@ -297,12 +297,12 @@ class EntriesController extends UserController
      */
     private function preview_fc2_template(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // 記事一覧データ設定
         $options = array(
             'where' => 'blog_id=?',
-            'params' => array($this->getBlogId($request)),
+            'params' => array($request->getBlogId()),
         );
         $pages = $request->get('page') ? array() : array('index_area');
         $this->setEntriesData($request, $options, $pages);
@@ -334,12 +334,12 @@ class EntriesController extends UserController
      */
     private function preview_template(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // 記事一覧データ設定
         $options = array(
             'where' => 'blog_id=?',
-            'params' => array($this->getBlogId($request)),
+            'params' => array($request->getBlogId()),
         );
         $pages = $request->get('page') ? array() : array('index_area');
         $this->setEntriesData($request, $options, $pages);
@@ -371,7 +371,7 @@ class EntriesController extends UserController
      */
     private function preview_plugin(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // プラグインのプレビュー情報取得
         if ($request->get('plugin_id')) {
@@ -425,7 +425,7 @@ class EntriesController extends UserController
         // 記事一覧データ設定(スマフォ版以外のプレビュー表示)
         $options = array(
             'where' => 'blog_id=?',
-            'params' => array($this->getBlogId($request)),
+            'params' => array($request->getBlogId()),
         );
         $pages = $request->get('page') ? array() : array('index_area');
         $this->setEntriesData($request, $options, $pages);
@@ -457,7 +457,7 @@ class EntriesController extends UserController
      */
     private function preview_entry(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // DBの代わりにリクエストから取得
         $entry = array(
@@ -509,7 +509,7 @@ class EntriesController extends UserController
      */
     public function view(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $entry_id = (int)$request->get('id');
 
         // 記事詳細取得
@@ -641,7 +641,7 @@ class EntriesController extends UserController
      */
     public function plugin(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $id = $request->get('id');
 
         // プラグイン取得
@@ -660,7 +660,7 @@ class EntriesController extends UserController
      */
     public function password(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $id = $request->get('id');
 
         // 記事詳細取得
@@ -691,7 +691,7 @@ class EntriesController extends UserController
      */
     public function blog_password(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         if (is_null($blog = BlogService::getById($blog_id))) {
             return $this->error404();
         }
@@ -723,7 +723,7 @@ class EntriesController extends UserController
      */
     public function comment_regist(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // ブログの設定情報取得(captchaの使用可否で画面切り替え)
         $blog_setting = (new BlogSettingsModel())->findByBlogId($blog_id);
@@ -812,7 +812,7 @@ class EntriesController extends UserController
      */
     public function comment_edit(Request $request): string
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
 
         // ブログの設定情報を取得
         $blog_setting = (new BlogSettingsModel())->findByBlogId($blog_id);
@@ -915,7 +915,7 @@ class EntriesController extends UserController
     {
         $comments_model = new CommentsModel();
 
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $comment_id = $request->get('comment.id');
         $comment = "";
         if (!$comment_id || !($comment = $comments_model->findByIdAndBlogId($comment_id, $blog_id)) || empty($comment['password'])) {
@@ -948,7 +948,7 @@ class EntriesController extends UserController
      */
     private function setEntriesData(Request $request, array $options = [], array $areas = []): void
     {
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         $page_num = $request->get('page', 0, Request::VALID_UNSIGNED_INT);
 
         // 検索条件生成

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -20,7 +20,6 @@ use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
 use InvalidArgumentException;
-use LogicException;
 use Tuupola\Base62Proxy;
 
 class EntriesController extends UserController
@@ -324,38 +323,6 @@ class EntriesController extends UserController
         }
 
         // FC2用のテンプレートで表示
-        return $this->getFc2TemplatePath($blog_id, $html, $css, true);
-    }
-
-    /**
-     * 一時的なテンプレートファイルの生成と実行（テスト用
-     * @param Request $request
-     * @param string $html テンプレートのString
-     * @param string $css テンプレートのCSS
-     * @return string temporary compiled template file path
-     */
-    public function test_template(Request $request, string $html, string $css): string
-    {
-        if (!defined("THIS_IS_TEST")) { // テスト以外ではブロックする
-            throw new LogicException("the method is allowed only in testing.");
-        }
-
-        $blog_id = $this->getBlogId($request);
-
-        // 記事一覧データ設定
-        $options = [
-            'where' => 'blog_id=?',
-            'params' => [$blog_id],
-        ];
-        $pages = $request->get('page') ? [] : ['index_area'];
-        $this->setEntriesData($request, $options, $pages);
-
-        // テンプレートのシンタックスチェック
-        $syntax = Fc2BlogTemplate::fc2TemplateSyntax($html);
-        if ($syntax !== true) {
-            throw new InvalidArgumentException("Syntax error in the generated template.");
-        }
-
         return $this->getFc2TemplatePath($blog_id, $html, $css, true);
     }
 

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -798,7 +798,7 @@ class EntriesController extends UserController
         $errors = array();
         $white_list = array('entry_id', 'name', 'title', 'mail', 'url', 'body', 'password', 'open_status');
         $errors['comment'] = $comments_model->registerValidate($request->get('comment'), $data, $white_list);
-        $errors['token'] = $is_captcha ? $this->tokenValidate($request) : array();   // Token用のバリデート
+        $errors['token'] = $is_captcha ? $this->captchaTokenValidate($request) : [];   // Token用のバリデート
         if (empty($errors['comment']) && empty($errors['token'])) {
             $data['blog_id'] = $blog_id;  // ブログIDの設定
             // trip_hashの生成
@@ -913,7 +913,7 @@ class EntriesController extends UserController
         $errors = [];
         $white_list = ['name', 'title', 'mail', 'url', 'body', 'password', 'open_status'];
         $errors['comment'] = $comments_model->editValidate($request->get('comment'), $data, $white_list, $comment);
-        $errors['token'] = $is_captcha ? $this->tokenValidate($request) : [];   // Token用のバリデート
+        $errors['token'] = $is_captcha ? $this->captchaTokenValidate($request) : [];   // Token用のバリデート
         if (empty($errors['comment']) && empty($errors['token'])) {
             if ($comments_model->updateByIdAndBlogIdAndBlogSetting($request, $data, $comment_id, $blog_id, $blog_setting)) {
                 $this->redirect($request, ['action' => 'view', 'blog_id' => $blog_id, 'id' => $entry_id], '#comment' . $comment_id);
@@ -932,6 +932,18 @@ class EntriesController extends UserController
         // FC2用のテンプレートで表示
         $this->setAreaData(['edit_area']);
         return $this->getFc2TemplatePath($blog_id);
+    }
+
+    /**
+     * Captcha tokenチェック
+     * @param Request $request
+     * @return string|null
+     */
+    private function captchaTokenValidate(Request $request): ?string
+    {
+        $value = $request->get('token', '');
+        $value = mb_convert_kana($value, 'n');
+        return Session::remove('token') == $value ? null : __('Token authentication is invalid');
     }
 
     /**

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -716,7 +716,7 @@ class EntriesController extends UserController
      * コメント投稿
      * @param Request $request
      * @return string
-     * @noinspection SpellCheckingInspection regist -> registration しかし互換性が壊れる
+     * TODO regist -> registration しかし互換性が壊れる
      */
     public function comment_regist(Request $request): string
     {

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -941,7 +941,6 @@ class EntriesController extends UserController
      * @param Request $request
      * @param array $options
      * @param array $areas
-     * TODO: これはコントローラが持つべきなのか？Modelでは？
      */
     private function setEntriesData(Request $request, array $options = [], array $areas = []): void
     {
@@ -966,7 +965,6 @@ class EntriesController extends UserController
      * @param array $override_options
      * @param int $page_num
      * @return array
-     * TODO: これはコントローラが持つべきなのか？Modelでは？
      */
     private static function getEntriesQueryOptions(
         string $blog_id,
@@ -1007,7 +1005,6 @@ class EntriesController extends UserController
      * @param string $blog_id
      * @param array $options
      * @return array
-     * TODO: これはコントローラが持つべきなのか？Modelでは？
      */
     private static function getEntriesArray(string $blog_id, array $options): array
     {

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -798,7 +798,7 @@ class EntriesController extends UserController
         $errors = array();
         $white_list = array('entry_id', 'name', 'title', 'mail', 'url', 'body', 'password', 'open_status');
         $errors['comment'] = $comments_model->registerValidate($request->get('comment'), $data, $white_list);
-        $errors['token'] = $is_captcha ? $this->captchaTokenValidate($request) : [];   // Token用のバリデート
+        $errors['token'] = $is_captcha && CommonController::isValidCaptcha($request) ? "" : __('Token authentication is invalid');
         if (empty($errors['comment']) && empty($errors['token'])) {
             $data['blog_id'] = $blog_id;  // ブログIDの設定
             // trip_hashの生成
@@ -913,7 +913,7 @@ class EntriesController extends UserController
         $errors = [];
         $white_list = ['name', 'title', 'mail', 'url', 'body', 'password', 'open_status'];
         $errors['comment'] = $comments_model->editValidate($request->get('comment'), $data, $white_list, $comment);
-        $errors['token'] = $is_captcha ? $this->captchaTokenValidate($request) : [];   // Token用のバリデート
+        $errors['token'] = $is_captcha && CommonController::isValidCaptcha($request) ? "" : __('Token authentication is invalid');
         if (empty($errors['comment']) && empty($errors['token'])) {
             if ($comments_model->updateByIdAndBlogIdAndBlogSetting($request, $data, $comment_id, $blog_id, $blog_setting)) {
                 $this->redirect($request, ['action' => 'view', 'blog_id' => $blog_id, 'id' => $entry_id], '#comment' . $comment_id);
@@ -932,18 +932,6 @@ class EntriesController extends UserController
         // FC2用のテンプレートで表示
         $this->setAreaData(['edit_area']);
         return $this->getFc2TemplatePath($blog_id);
-    }
-
-    /**
-     * Captcha tokenチェック
-     * @param Request $request
-     * @return string|null
-     */
-    private function captchaTokenValidate(Request $request): ?string
-    {
-        $value = $request->get('token', '');
-        $value = mb_convert_kana($value, 'n');
-        return Session::remove('token') == $value ? null : __('Token authentication is invalid');
     }
 
     /**

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -716,6 +716,7 @@ class EntriesController extends UserController
      * コメント投稿
      * @param Request $request
      * @return string
+     * @noinspection SpellCheckingInspection regist -> registration しかし互換性が壊れる
      */
     public function comment_regist(Request $request): string
     {
@@ -1137,7 +1138,7 @@ class EntriesController extends UserController
               return ;
             }
             if (target.type==='checkbox') {
-              if (value===$open_status_private) {
+              if (value==={$open_status_private}) {
                 target.checked = 'checked';
               }
             } else {

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -4,6 +4,7 @@ namespace Fc2blog\Web\Controller\User;
 
 use Fc2blog\App;
 use Fc2blog\Config;
+use Fc2blog\Model\Blog;
 use Fc2blog\Model\BlogPluginsModel;
 use Fc2blog\Model\BlogSettingsModel;
 use Fc2blog\Model\BlogsModel;
@@ -40,14 +41,14 @@ class EntriesController extends UserController
         $this->set('blog_id', $blog_id);
 
         // 指定のブログが実在するかチェック
-        if (!($blog = $this->getBlog($blog_id)) || !is_array($blog)) {
+        if (!($blog = BlogService::getById($blog_id)) || !($blog instanceof Blog)) {
             Log::notice("not found blog, redirect to top. blog_id: {$blog_id}");
             $this->redirect($request, ['controller' => 'Blogs', 'action' => 'index']);
         }
 
         // BlogのSSL_Enableの設定と食い違うなら強制リダイレクトする
         // URL構造そのままでリダイレクトするためにRequestUriを用いているがもっとベターな方法があるかもしれない
-        if (!BlogsModel::isCorrectHttpSchemaByBlogArray($request, $blog)) {
+        if (!BlogsModel::isCorrectHttpSchemaByBlog($request, $blog)) {
             Log::debug("mismatch access schema and blog's schema. redirect to correct schema. blog_id:{$blog['id']}");
             $this->redirect($request, $request->uri, '', true, $blog['id']);
         }
@@ -1106,7 +1107,7 @@ class EntriesController extends UserController
         if (!is_file($templateFilePath) || $is_preview) {
             Log::debug_log(__FILE__ . ":" . __LINE__ . " generate Fc2Template. :{$templateFilePath}");
 
-            $blog = $this->getBlog($blog_id);
+            $blog = BlogService::getById($blog_id);
             $templateId = $blog[Config::get('BLOG_TEMPLATE_COLUMN.' . $device_type)];
 
             // HTMLとCSSの実行PHPを生成

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -16,6 +16,7 @@ use Fc2blog\Model\Model;
 use Fc2blog\Model\TagsModel;
 use Fc2blog\Service\BlogService;
 use Fc2blog\Util\Log;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
 use InvalidArgumentException;
@@ -317,7 +318,7 @@ class EntriesController extends UserController
         $css = $template['css'];
 
         // テンプレートのシンタックスチェック
-        $syntax = BlogTemplatesModel::fc2TemplateSyntax($html);
+        $syntax = Fc2BlogTemplate::fc2TemplateSyntax($html);
         if ($syntax !== true) {
             return 'user/entries/syntax_error.twig';
         }
@@ -350,7 +351,7 @@ class EntriesController extends UserController
         $this->setEntriesData($request, $options, $pages);
 
         // テンプレートのシンタックスチェック
-        $syntax = BlogTemplatesModel::fc2TemplateSyntax($html);
+        $syntax = Fc2BlogTemplate::fc2TemplateSyntax($html);
         if ($syntax !== true) {
             throw new InvalidArgumentException("Syntax error in the generated template.");
         }
@@ -386,7 +387,7 @@ class EntriesController extends UserController
         }
 
         // テンプレートのシンタックスチェック
-        $syntax = BlogTemplatesModel::fc2TemplateSyntax($html);
+        $syntax = Fc2BlogTemplate::fc2TemplateSyntax($html);
         if ($syntax !== true) {
             return 'user/entries/syntax_error.twig';
         }

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -461,7 +461,7 @@ class EntriesController extends UserController
         $this->setEntriesData($request, $options, $pages);
 
         // 通常のプラグインリストに追加する
-        $plugins = (new BlogPluginsModel())->findByDeviceTypeAndCategory($this->getDeviceType(), $category, $blog_id);
+        $plugins = (new BlogPluginsModel())->findByDeviceTypeAndCategory($this->request->deviceType, $category, $blog_id);
         $id = $request->get('id');
         if (empty($id)) {
             // 新規プラグインは最後尾に追加する
@@ -1097,7 +1097,7 @@ class EntriesController extends UserController
      */
     private function getFc2TemplatePath($blog_id, string $html = null, string $css = null, bool $is_preview = false): string
     {
-        $device_type = $this->getDeviceType();
+        $device_type = $this->request->deviceType;
 
         $templateFilePath = BlogTemplatesModel::getTemplateFilePath($blog_id, $device_type, $is_preview);
 

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -968,7 +968,7 @@ class EntriesController extends UserController
      * @return array
      * TODO: これはコントローラが持つべきなのか？Modelでは？
      */
-    public static function getEntriesQueryOptions(
+    private static function getEntriesQueryOptions(
         string $blog_id,
         array $override_options,
         int $page_num
@@ -1009,7 +1009,7 @@ class EntriesController extends UserController
      * @return array
      * TODO: これはコントローラが持つべきなのか？Modelでは？
      */
-    public static function getEntriesArray(string $blog_id, array $options): array
+    private static function getEntriesArray(string $blog_id, array $options): array
     {
         $entries_model = new EntriesModel();
         $entries = $entries_model->find('all', $options);

--- a/app/src/Web/Controller/User/UserController.php
+++ b/app/src/Web/Controller/User/UserController.php
@@ -13,16 +13,6 @@ use InvalidArgumentException;
 abstract class UserController extends Controller
 {
     /**
-     * ブログID取得
-     * @param Request $request
-     * @return string|null
-     */
-    public static function getBlogId(Request $request): ?string
-    {
-        return $request->getBlogId();
-    }
-
-    /**
      * 管理画面ログイン中のブログIDを取得する
      */
     protected static function getAdminBlogId(): ?string
@@ -51,7 +41,7 @@ abstract class UserController extends Controller
             return false;
         }
         // セッションに持っているログイン中のブログIDを取得
-        $blog_id = $this->getBlogId($request);
+        $blog_id = $request->getBlogId();
         if ($admin_blog_id == $blog_id) {
             return true;
         }

--- a/app/src/Web/Controller/User/UserController.php
+++ b/app/src/Web/Controller/User/UserController.php
@@ -5,8 +5,10 @@ namespace Fc2blog\Web\Controller\User;
 
 use Fc2blog\Model\BlogsModel;
 use Fc2blog\Web\Controller\Controller;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
+use InvalidArgumentException;
 
 abstract class UserController extends Controller
 {
@@ -78,5 +80,32 @@ abstract class UserController extends Controller
     {
         /** @noinspection PhpUnnecessaryStringCastInspection */
         return 'entry_password.' . $blog_id . '.' . (string)$entry_id;
+    }
+
+    /**
+     * FC2タグを用いたユーザーテンプレート（PHP）でHTMLをレンダリング
+     * @param Request $request
+     * @param string $template_file_path
+     * @return string
+     */
+    protected function renderByFc2Template(Request $request, string $template_file_path): string
+    {
+        if (is_null($template_file_path)) {
+            throw new InvalidArgumentException("undefined template");
+        }
+        if (!is_file($template_file_path)) {
+            throw new InvalidArgumentException("missing template");
+        }
+
+        $this->data = Fc2BlogTemplate::preprocessingData($request, $this->data);
+
+        // 設定されているdataをローカルスコープに展開
+        extract($this->data);
+
+        // テンプレートをレンダリングして返す
+        ob_start();
+        /** @noinspection PhpIncludeInspection */
+        include($template_file_path);
+        return ob_get_clean();
     }
 }

--- a/app/src/Web/Fc2BlogTemplate.php
+++ b/app/src/Web/Fc2BlogTemplate.php
@@ -6,7 +6,6 @@ namespace Fc2blog\Web;
 use Fc2blog\App;
 use Fc2blog\Config;
 use Fc2blog\Util\PhpCodeLinter;
-use Fc2blog\Web\Controller\User\UserController;
 
 class Fc2BlogTemplate
 {
@@ -90,7 +89,7 @@ class Fc2BlogTemplate
         }
 
         // FC2用のどこでも有効な単変数
-        $data['blog_id'] = UserController::getBlogId($request); // TODO User系でしかこのメソッドは呼ばれないはずなので
+        $data['blog_id'] = $request->getBlogId(); // TODO User系でしかこのメソッドは呼ばれないはずなので
         if ($data['blog_id'] !== Config::get('DEFAULT_BLOG_ID')) {
             $data['url'] = '/' . $data['blog']['id'] . '/';
         } else {

--- a/app/src/Web/Fc2BlogTemplate.php
+++ b/app/src/Web/Fc2BlogTemplate.php
@@ -1,0 +1,109 @@
+<?php
+declare(strict_types=1);
+
+namespace Fc2blog\Web;
+
+use Fc2blog\App;
+use Fc2blog\Config;
+use Fc2blog\Web\Controller\User\UserController;
+
+class Fc2BlogTemplate
+{
+    /**
+     * fc2blog形式のPHP Viewテンプレート内で利用する各種データを生成・変換
+     * @param Request $request
+     * @param array $data
+     * @return array
+     */
+    static public function preprocessingData(Request $request, array $data): array
+    {
+        $data['request'] = $request;
+
+        // FC2のテンプレート用にデータを置き換える
+        if (!empty($data['entry'])) {
+            $data['entries'] = [$data['entry']];
+        }
+        if (!empty($data['entries'])) {
+            foreach ($data['entries'] as $key => $value) {
+                // topentry系変数のデータ設定
+                $data['entries'][$key]['title_w_img'] = $value['title'];
+                $data['entries'][$key]['title'] = strip_tags($value['title']);
+                $data['entries'][$key]['link'] = App::userURL($request, ['controller' => 'Entries', 'action' => 'view', 'blog_id' => $value['blog_id'], 'id' => $value['id']]);
+
+                [
+                    $data['entries'][$key]['year'],
+                    $data['entries'][$key]['month'],
+                    $data['entries'][$key]['day'],
+                    $data['entries'][$key]['hour'],
+                    $data['entries'][$key]['minute'],
+                    $data['entries'][$key]['second'],
+                    $data['entries'][$key]['youbi'],
+                    $data['entries'][$key]['month_short']
+                ] = explode('/', date('Y/m/d/H/i/s/D/M', strtotime($value['posted_at'])));
+                $data['entries'][$key]['wayoubi'] = __($data['entries'][$key]['youbi']);
+
+                // 自動改行処理
+                if ($value['auto_linefeed'] == Config::get('ENTRY.AUTO_LINEFEED.USE')) {
+                    $data['entries'][$key]['body'] = nl2br($value['body']);
+                    $data['entries'][$key]['extend'] = nl2br($value['extend']);
+                }
+
+                // topentry_enc_* 系タグの生成
+                $data['entries'][$key]['enc_title'] = urlencode($data['entries'][$key]['title']);
+                $data['entries'][$key]['enc_utftitle'] = urlencode($data['entries'][$key]['title']);
+                $data['entries'][$key]['enc_link'] = urlencode($data['entries'][$key]['link']);
+            }
+        }
+
+        // コメント一覧の情報
+        if (!empty($data['comments'])) {
+            foreach ($data['comments'] as $key => $value) {
+                $data['comments'][$key]['edit_link'] = Html::url($request, ['controller' => 'Entries', 'action' => 'comment_edit', 'blog_id' => $value['blog_id'], 'id' => $value['id']]);
+
+                [
+                    $data['comments'][$key]['year'],
+                    $data['comments'][$key]['month'],
+                    $data['comments'][$key]['day'],
+                    $data['comments'][$key]['hour'],
+                    $data['comments'][$key]['minute'],
+                    $data['comments'][$key]['second'],
+                    $data['comments'][$key]['youbi']
+                ] = explode('/', date('Y/m/d/H/i/s/D', strtotime($value['updated_at'])));
+                $data['comments'][$key]['wayoubi'] = __($data['comments'][$key]['youbi']);
+                $data['comments'][$key]['body'] = $value['body']; // TODO nl2brされていないのは正しいのか？
+
+                $value['reply_updated_at'] = $value['reply_updated_at'] ?? ""; // reply_updated_at is nullable
+                $reply_updated_at = strtotime($value['reply_updated_at']) ?: 0;
+                [
+                    $data['comments'][$key]['reply_year'],
+                    $data['comments'][$key]['reply_month'],
+                    $data['comments'][$key]['reply_day'],
+                    $data['comments'][$key]['reply_hour'],
+                    $data['comments'][$key]['reply_minute'],
+                    $data['comments'][$key]['reply_second'],
+                    $data['comments'][$key]['reply_youbi']
+                ] = explode('/', date('Y/m/d/H/i/s/D', $reply_updated_at));
+                $data['comments'][$key]['reply_wayoubi'] = __($data['comments'][$key]['reply_youbi']);
+                $data['comments'][$key]['reply_body'] = nl2br((string)$value['reply_body']);
+            }
+        }
+
+        // FC2用のどこでも有効な単変数
+        $data['blog_id'] = UserController::getBlogId($request); // TODO User系でしかこのメソッドは呼ばれないはずなので
+        if ($data['blog_id'] !== Config::get('DEFAULT_BLOG_ID')) {
+            $data['url'] = '/' . $data['blog']['id'] . '/';
+        } else {
+            // シングルテナントモード、DEFAULT_BLOG_IDとBlogIdが一致するなら、Pathを省略する
+            $data['url'] = '/';
+        }
+
+        // 年月日系
+        $data['now_date'] = (isset($data['date_area']) && $data['date_area']) ? $data['now_date'] : date('Y-m-d');
+        $data['now_month_date'] = date('Y-m-1', strtotime($data['now_date']));
+        $data['prev_month_date'] = date('Y-m-1', strtotime($data['now_month_date'] . ' -1 month'));
+        $data['next_month_date'] = date('Y-m-1', strtotime($data['now_month_date'] . ' +1 month'));
+
+        return $data;
+    }
+
+}

--- a/app/src/Web/Request.php
+++ b/app/src/Web/Request.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Fc2blog\Web;
 
 use Fc2blog\App;
+use Fc2blog\Config;
 use Fc2blog\Util\I18n;
 use Fc2blog\Util\Log;
 use Fc2blog\Web\Router\Router;
@@ -400,5 +401,17 @@ class Request
     public function isHttps(): bool
     {
         return isset($this->server["HTTPS"]) && $this->server["HTTPS"] === "on";
+    }
+
+    /**
+     * 自身の`http(s)://FQDN(:port)`を設定から生成する
+     * @return string
+     */
+    public function getHostUrl(): string
+    {
+        $schema = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === "on") ? 'https:' : 'http:';
+        $domain = Config::get("DOMAIN");
+        $port = ($schema === "https:") ? Config::get("HTTPS_PORT_STR") : Config::get("HTTP_PORT_STR");
+        return $schema . "//" . $domain . $port;
     }
 }

--- a/app/src/Web/Router/Router.php
+++ b/app/src/Web/Router/Router.php
@@ -46,20 +46,20 @@ class Router
             $request->urlRewrite = true;
             $request->baseDirectory = '/admin/';
 
-            // default controller/method
-            $this->className = \Fc2blog\Web\Controller\Admin\CommonController::class;
-            $this->methodName = 'index';
-
             if ($request->isArgs($args_controller)) {
                 $this->className = "Fc2blog\\Web\\Controller\\Admin\\" . StringCaseConverter::pascalCase($request->get($args_controller)) . "Controller";
             } elseif (isset($paths[1])) {
                 $this->className = "Fc2blog\\Web\\Controller\\Admin\\" . StringCaseConverter::pascalCase($paths[1]) . "Controller";
+            } else {
+                $this->className = \Fc2blog\Web\Controller\Admin\CommonController::class;
             }
 
             if ($request->isArgs($args_action)) {
                 $this->methodName = $request->get($args_action);
             } elseif (isset($paths[2])) {
                 $this->methodName = $paths[2];
+            } else {
+                $this->methodName = 'index';
             }
 
         } else { // User 画面ルーティング
@@ -67,28 +67,24 @@ class Router
             $request->baseDirectory = '/';
 
             // 対象となるblogを決定する
-            if (!is_null($request->getBlogId())) {
+            if (!is_null($blog_id = $request->getBlogId())) {
                 // URLからDefault Blog IDが取得できる場合
-                $blog_id = $request->getBlogId();
-                $request->set('blog_id', $blog_id);
                 if (isset($paths[1])) {
                     $sub_path = $paths[1];
                 }
-            } else if (!is_null($request->get('blog_id'))) {
+            } else if (!is_null($blog_id = $request->get('blog_id'))) {
                 // パラメタからBlog idが取得できる場合
-                $blog_id = $request->get('blog_id');
-                $request->set('blog_id', $blog_id);
                 if (isset($paths[0])) {
                     $sub_path = $paths[0];
                 }
             } else {
                 // blog_idがリクエストから特定できない場合、デフォルトblog_idを利用する
                 $blog_id = BlogsModel::getDefaultBlogId();
-                $request->set('blog_id', $blog_id);
                 if (isset($paths[0])) {
                     $sub_path = $paths[0];
                 }
             }
+            $request->set('blog_id', $blog_id);
 
             if (isset($blog_id) && $request->isArgs('xml')) { // `/?xml`
                 // http://example.jp/blogid/*?xml が対応

--- a/app/src/include/common_functions.php
+++ b/app/src/include/common_functions.php
@@ -73,11 +73,12 @@ function ue(?string $text): string
  * 日付のフォーマット変更
  * @param $date
  * @param string $format
- * @return false|string
+ * @return string
+ * TODO 使われていない？
  */
-function df($date, $format = 'Y/m/d H:i:s'): string
+function df($date, string $format = 'Y/m/d H:i:s'): string
 {
-    return date($format, strtotime($date));
+    return (string)date($format, strtotime($date));
 }
 
 /**

--- a/app/src/include/index_include.php
+++ b/app/src/include/index_include.php
@@ -38,25 +38,24 @@ register_shutdown_function(function () {
         http_response_code(500);
     }
     echo <<<HTML
-  <!DOCTYPE html>
-  <html lang="en">
-  <head>
-  <title>Internal Server Error</title>
-  </head>
-  <body>
-    <h1>500 Internal Server Error</h1>
-    <p>Something went wrong.</p>
-    <p>(Please check error log)</p>
-  HTML;
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <title>Internal Server Error</title>
+    </head>
+    <body>
+        <h1>500 Internal Server Error</h1>
+        <p>Something went wrong. / 処理中にエラーが発生しました。</p>
+    HTML;
     if (defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY === "1") {
         echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><br>";
         echo nl2br(htmlspecialchars($something . PHP_EOL, ENT_QUOTES));
         echo nl2br(htmlspecialchars("Uncaught Fatal Error: {$error['type']}:{$error['message']} in {$error['file']}:{$error['line']}"));
     }
     echo <<<HTML
-  </body>
-  </html>
-  HTML;
+    </body>
+    </html>
+    HTML;
 });
 
 try {
@@ -74,24 +73,24 @@ try {
     if (!file_exists(__DIR__ . '/../../config.php') && (string)getenv("FC2_CONFIG_FROM_ENV") !== "1") {
         header("Content-Type: text/html; charset=UTF-8");
         echo <<<HTML
-    <!DOCTYPE html>
-    <html lang="ja">
-    <head>
-    <title>Does not exists config.php</title>
-    </head>
-    <body>
-      Does not exists config.php / config.phpが存在しておりません
-      <p class="ng">
-        Please copy app/config.sample.php to app/config.php and edit them.<br>
-        app/config.sample.phpをapp/config.phpにコピーしファイル内に存在するDBの接続情報とサーバーの設定情報を入力してください。
-      </p>
-    </body>
-    </html>
-    HTML;
+        <!DOCTYPE html>
+        <html lang="ja">
+        <head>
+            <title>Does not exists config.php</title>
+        </head>
+        <body>
+            Does not exists config.php / config.phpが存在しておりません
+            <p class="ng">
+                Please copy app/config.sample.php to app/config.php and edit them.<br>
+                app/config.sample.phpをapp/config.phpにコピーしファイル内に存在するDBの接続情報とサーバーの設定情報を入力してください。
+            </p>
+        </body>
+        </html>
+        HTML;
         return;
     }
 
-// 設定クラス読み込み
+    // 設定クラス読み込み
     if ((string)getenv("FC2_CONFIG_FROM_ENV") === "1") {
         require(__DIR__ . '/../../config_read_from_env.php');
     } else {
@@ -107,17 +106,14 @@ try {
     $c->execute($request->methodName);
 
     // TODO Logging un-excepted output buffer(debug|error messages|other)
-    //  $something = ob_get_contents();
-    //  if (strlen($something) > 0) {
-    //    error_log($something);
-    //  }
-    //  ob_end_clean();
-    //  ob_start();
+    // $something = ob_get_contents();
+    // if (strlen($something) > 0) {
+    //     error_log($something);
+    // }
+    // ob_end_clean();
+    // ob_start();
     // TODO remove all `echo` in app. ex: captcha
 
-    if (defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY === "1") {
-        echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><hr>";
-    }
     $c->emit();
     ob_end_flush();
     return;
@@ -141,24 +137,23 @@ try {
         http_response_code(500);
     }
     echo <<<HTML
-  <!DOCTYPE html>
-  <html lang="en">
-  <head>
-  <title>Internal Server Error</title>
-  </head>
-  <body>
-    <h1>500 Internal Server Error</h1>
-    <p>Something went wrong.</p>
-    <p>(Please check error log)</p>
-  HTML;
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+        <title>Internal Server Error</title>
+    </head>
+    <body>
+        <h1>500 Internal Server Error</h1>
+        <p>Something went wrong. / 処理中にエラーが発生しました。</p>
+    HTML;
     if (defined("ERROR_ON_DISPLAY") && ERROR_ON_DISPLAY === "1") {
         echo "<hr><span style='color:red'>THE BLOG CONFIGURATION IS DANGER. PLEASE REMOVE `ERROR_ON_DISPLAY` in production.</span><br>";
         echo nl2br(htmlspecialchars($something . PHP_EOL, ENT_QUOTES));
         echo nl2br(htmlspecialchars("Uncaught Exception {$error_class_name}: {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}\n{$e->getTraceAsString()}"));
     }
     echo <<<HTML
-  </body>
-  </html>
-  HTML;
+    </body>
+    </html>
+    HTML;
     return;
 }

--- a/tests/App/Controller/Admin/BlogTemplates/CreateTest.php
+++ b/tests/App/Controller/Admin/BlogTemplates/CreateTest.php
@@ -28,7 +28,7 @@ class CreateTest extends TestCase
         $this->resetCookie();
         $this->mergeAdminSession();
 
-        $c = $this->reqGet("/admin/blog_templates/create", ['device_type' => 1]);
+        $c = $this->reqGet("/admin/blog_templates/create", ['device_type' => "1"]);
         $this->assertInstanceOf(BlogTemplatesController::class, $c);
         $this->assertEquals('create', $c->getResolvedMethod());
 

--- a/tests/App/Controller/Admin/Files/EditTest.php
+++ b/tests/App/Controller/Admin/Files/EditTest.php
@@ -85,7 +85,7 @@ class EditTest extends TestCase
         ];
         $filename = "test" . microtime(true) . ".png";
         $request_data = [
-            'id' => $files[0]['id'],
+            'id' => (string)$files[0]['id'],
             'file' => [
                 "name" => $filename,
             ],

--- a/tests/App/Fc2Template/Fc2TemplateIfTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateIfTest.php
@@ -5,7 +5,7 @@ namespace Fc2blog\Tests\App\Fc2Template;
 
 use ErrorException;
 use Fc2blog\Config;
-use Fc2blog\Model\BlogTemplatesModel;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Request;
 use ParseError;
 use PHPUnit\Framework\TestCase;
@@ -362,15 +362,9 @@ class Fc2TemplateIfTest extends TestCase
     public function ifStateTester($tag, $expected, $env)
     {
         $input_template = "<!--{$tag}-->ok<!--/{$tag}-->";
-        $php_template = $this->convertFc2TemplateToPhpTemplate($input_template);
+        $php_template = Fc2BlogTemplate::convertToPhp($input_template);
         $res = $this->evalPhpTemplate($php_template, $env);
         $this->assertEquals($expected, $res);
-    }
-
-    public function convertFc2TemplateToPhpTemplate(string $input_template): string
-    {
-        $b = new BlogTemplatesModel();
-        return $b->convertFC2Template($input_template);
     }
 
     /**

--- a/tests/App/Fc2Template/Fc2TemplateLoopTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateLoopTest.php
@@ -5,7 +5,7 @@ namespace Fc2blog\Tests\App\Fc2Template;
 
 use ErrorException;
 use Fc2blog\Config;
-use Fc2blog\Model\BlogTemplatesModel;
+use Fc2blog\Web\Fc2BlogTemplate;
 use ParseError;
 use PHPUnit\Framework\TestCase;
 use TypeError;
@@ -54,16 +54,10 @@ class Fc2TemplateLoopTest extends TestCase
     public function loopStateTester($tag, $expected, $env)
     {
         $input_template = "<!--{$tag}-->ok<!--/{$tag}-->";
-        $php_template = $this->convertFc2TemplateToPhpTemplate($input_template);
+        $php_template = Fc2BlogTemplate::convertToPhp($input_template);
         $res = $this->evalPhpTemplate($php_template, $env);
 //    var_dump($res);
         $this->assertEquals($expected, $res);
-    }
-
-    public function convertFc2TemplateToPhpTemplate(string $input_template): string
-    {
-        $b = new BlogTemplatesModel();
-        return $b->convertFC2Template($input_template);
     }
 
     /**

--- a/tests/App/Fc2Template/Fc2TemplateTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateTest.php
@@ -8,7 +8,6 @@ use Fc2blog\Config;
 use Fc2blog\Exception\RedirectExit;
 use Fc2blog\Model\BlogSettingsModel;
 use Fc2blog\Model\BlogsModel;
-use Fc2blog\Model\BlogTemplatesModel;
 use Fc2blog\Model\CommentsModel;
 use Fc2blog\Model\EntriesModel;
 use Fc2blog\Model\EntryCategoriesModel;
@@ -617,12 +616,11 @@ class Fc2TemplateTest extends TestCase
     public function getAllPrintableTagEval(Request $request, array $data): void
     {
         $printable_tags = Config::get('fc2_template_var_search');
-        $b = new BlogTemplatesModel();
         foreach ($printable_tags as $tag_str => $printable_tag) {
             // タグの含まれたHTML
             $input_html = "{$printable_tag}";
             // 変換されたPHP
-            $converted_php = $b->convertFC2Template($input_html);
+            $converted_php = Fc2BlogTemplate::convertToPhp($input_html);
             $this->fragmentRunner(Fc2BlogTemplate::preprocessingData($request, $data), $tag_str, $converted_php);
         }
     }
@@ -635,10 +633,9 @@ class Fc2TemplateTest extends TestCase
     public function getAllIfCondEval(Request $request, array $data): void
     {
         $fc2_template_if_list = Config::get('fc2_template_if');
-        $b = new BlogTemplatesModel();
         foreach ($fc2_template_if_list as $tag_str => $php_code) {
             $input_html = "<!--{$tag_str}-->BODY<!--/{$tag_str}-->";
-            $converted_php = $b->convertFC2Template($input_html);
+            $converted_php = Fc2BlogTemplate::convertToPhp($input_html);
             $this->fragmentRunner(Fc2BlogTemplate::preprocessingData($request, $data), $tag_str, $converted_php);
         }
     }
@@ -651,10 +648,9 @@ class Fc2TemplateTest extends TestCase
     public function getAllForEachCondEval(Request $request, array $data): void
     {
         $fc2_template_if_list = Config::get('fc2_template_foreach');
-        $b = new BlogTemplatesModel();
         foreach ($fc2_template_if_list as $tag_str => $php_code) {
             $input_html = "<!--{$tag_str}-->BODY<!--/{$tag_str}-->";
-            $converted_php = $b->convertFC2Template($input_html);
+            $converted_php = Fc2BlogTemplate::convertToPhp($input_html);
             $this->fragmentRunner(Fc2BlogTemplate::preprocessingData($request, $data), $tag_str, $converted_php);
         }
     }

--- a/tests/App/Fc2Template/Fc2TemplateTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateTest.php
@@ -18,8 +18,8 @@ use Fc2blog\Tests\Helper\SampleDataGenerator\GenerateSampleCategory;
 use Fc2blog\Tests\Helper\SampleDataGenerator\GenerateSampleComment;
 use Fc2blog\Tests\Helper\SampleDataGenerator\GenerateSampleEntry;
 use Fc2blog\Tests\Helper\SampleDataGenerator\GenerateSampleTag;
-use Fc2blog\Web\Controller\Controller;
 use Fc2blog\Web\Controller\User\EntriesController;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Request;
 use ParseError;
 use PHPUnit\Framework\TestCase;
@@ -623,7 +623,7 @@ class Fc2TemplateTest extends TestCase
             $input_html = "{$printable_tag}";
             // 変換されたPHP
             $converted_php = $b->convertFC2Template($input_html);
-            $this->fragmentRunner(Controller::preprocessingDataForFc2Template($request, $data), $tag_str, $converted_php);
+            $this->fragmentRunner(Fc2BlogTemplate::preprocessingData($request, $data), $tag_str, $converted_php);
         }
     }
 
@@ -639,7 +639,7 @@ class Fc2TemplateTest extends TestCase
         foreach ($fc2_template_if_list as $tag_str => $php_code) {
             $input_html = "<!--{$tag_str}-->BODY<!--/{$tag_str}-->";
             $converted_php = $b->convertFC2Template($input_html);
-            $this->fragmentRunner(Controller::preprocessingDataForFc2Template($request, $data), $tag_str, $converted_php);
+            $this->fragmentRunner(Fc2BlogTemplate::preprocessingData($request, $data), $tag_str, $converted_php);
         }
     }
 
@@ -655,7 +655,7 @@ class Fc2TemplateTest extends TestCase
         foreach ($fc2_template_if_list as $tag_str => $php_code) {
             $input_html = "<!--{$tag_str}-->BODY<!--/{$tag_str}-->";
             $converted_php = $b->convertFC2Template($input_html);
-            $this->fragmentRunner(Controller::preprocessingDataForFc2Template($request, $data), $tag_str, $converted_php);
+            $this->fragmentRunner(Fc2BlogTemplate::preprocessingData($request, $data), $tag_str, $converted_php);
         }
     }
 

--- a/tests/App/Fc2Template/Fc2TemplateTest.php
+++ b/tests/App/Fc2Template/Fc2TemplateTest.php
@@ -243,7 +243,7 @@ class Fc2TemplateTest extends TestCase
             []
         );
         $entry_controller = new EntriesController($request);
-        $entry_controller->prepare('archives');
+        $entry_controller->prepare('archive');
 
         ## 疑似実行
         $this->evalAll($request, $entry_controller->getData());

--- a/tests/App/Lib/CaptchaImage/DrawNumberTest.php
+++ b/tests/App/Lib/CaptchaImage/DrawNumberTest.php
@@ -1,4 +1,5 @@
-<?php /** @noinspection PhpUnhandledExceptionInspection */
+<?php /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection GdImageはPHP>=8だが、このコードはテストコードなので */
+/** @noinspection PhpUnhandledExceptionInspection */
 
 declare(strict_types=1);
 

--- a/tests/App/Model/BlogsModel/IsCorrectHttpSchemaByBlogArrayTest.php
+++ b/tests/App/Model/BlogsModel/IsCorrectHttpSchemaByBlogArrayTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Fc2blog\Tests\App\Model\BlogsModel;
 
 use Fc2blog\Config;
+use Fc2blog\Model\Blog;
 use Fc2blog\Model\BlogsModel;
 use Fc2blog\Web\Request;
 use PHPUnit\Framework\TestCase;
@@ -19,14 +20,17 @@ class IsCorrectHttpSchemaByBlogArrayTest extends TestCase
                 'HTTPS' => "on"
             ]
         );
-        $this->assertFalse(BlogsModel::isCorrectHttpSchemaByBlogArray($request, ['ssl_enable' => Config::get('BLOG.SSL_ENABLE.DISABLE')]));
+        $blog = new Blog();
+        $blog->ssl_enable = Config::get('BLOG.SSL_ENABLE.DISABLE');
+        $this->assertFalse(BlogsModel::isCorrectHttpSchemaByBlog($request, $blog));
         $request = new Request(
             'GET', '/', null, null, null, null,
             [
                 'HTTP_USER_AGENT' => 'phpunit',
             ]
         );
-        $this->assertTrue(BlogsModel::isCorrectHttpSchemaByBlogArray($request, ['ssl_enable' => Config::get('BLOG.SSL_ENABLE.DISABLE')]));
+        $blog->ssl_enable = Config::get('BLOG.SSL_ENABLE.DISABLE');
+        $this->assertTrue(BlogsModel::isCorrectHttpSchemaByBlog($request, $blog));
 
         $request = new Request(
             'GET', '/', null, null, null, null,
@@ -35,13 +39,15 @@ class IsCorrectHttpSchemaByBlogArrayTest extends TestCase
                 'HTTPS' => "on"
             ]
         );
-        $this->assertTrue(BlogsModel::isCorrectHttpSchemaByBlogArray($request, ['ssl_enable' => Config::get('BLOG.SSL_ENABLE.ENABLE')]));
+        $blog->ssl_enable = Config::get('BLOG.SSL_ENABLE.ENABLE');
+        $this->assertTrue(BlogsModel::isCorrectHttpSchemaByBlog($request, $blog));
         $request = new Request(
             'GET', '/', null, null, null, null,
             [
                 'HTTP_USER_AGENT' => 'phpunit',
             ]
         );
-        $this->assertFalse(BlogsModel::isCorrectHttpSchemaByBlogArray($request, ['ssl_enable' => Config::get('BLOG.SSL_ENABLE.ENABLE')]));
+        $blog->ssl_enable = Config::get('BLOG.SSL_ENABLE.ENABLE');
+        $this->assertFalse(BlogsModel::isCorrectHttpSchemaByBlog($request, $blog));
     }
 }

--- a/tests/Helper/ClientTrait.php
+++ b/tests/Helper/ClientTrait.php
@@ -7,6 +7,7 @@ use Fc2blog\Exception\RedirectExit;
 use Fc2blog\Model\EntriesModel;
 use Fc2blog\Web\Controller\Controller;
 use Fc2blog\Web\Controller\User\UserController;
+use Fc2blog\Web\Fc2BlogTemplate;
 use Fc2blog\Web\Request;
 use Fc2blog\Web\Session;
 use RuntimeException;
@@ -253,7 +254,7 @@ trait ClientTrait
         /** @var UserController $c */
         $c = new $request->className($request);
         $c->prepare($request->methodName);
-        $d = Controller::preprocessingDataForFc2Template($request, $c->getData());
+        $d = Fc2BlogTemplate::preprocessingData($request, $c->getData());
         // App::userURLのテストのため
         $em = new EntriesModel();
         $d['_calender_data'] = $em->getTemplateCalendar($request, $c->get('blog_id'), 2020, 7); // テストデータに依存しているので、壊れやすい

--- a/tests/Helper/ClientTrait.php
+++ b/tests/Helper/ClientTrait.php
@@ -152,7 +152,6 @@ trait ClientTrait
 
         $c = new $request->className($request);
 
-        $exception = null;
         try {
             $c->execute($request->methodName);
             $c->emit();


### PR DESCRIPTION
rel #108 #256

- `Controller` 親クラスの責務を分割し、処理を必要なクラスに移譲。
- 全 `Controller` に `declare(strict_types=1);` を付与し、暗黙の型変換を抑制、型変換を明示的に記述
- 存在しないactionへのアクセスを404にするために`__call`をつかっていたのを廃止（すでにRouterでフィルター済み）
- Captchaでしかつかわれていないコードの統廃合
- すでに不要となっていたメソッドの消し込み
- #84 配列として扱える、Rowモデルクラス関連の適用拡大と改善
- Fatになっていた`BlogTemplatesModel` からテンプレート関連のコンパイル、文法チェック等のロジックを `Fc2BlogTemplate` に分割し、静的解析に対する透明性の向上。
- Controller以外も `declare(strict_types=1);` の範囲を拡大
- Admin系の`getBlogId` 不要な引数の削減と、名称変更
- 古いチェックコードから、 `Request::isValidSig()` に書き換えて揃えた
- Typoの修正
- 一部アクセス修飾子をPrivateやProtectedに是正
- 検討の結果、不要となったTODOの削除
- #256 500エラー画面を改善、デバッグモード時にtext/html以外の場合はワーニングをださないように修正
- `UserController::getBlogId` を `$request->getBlogId()` に変更し、削除
- #108 Router のリファクタリング、不要なバリデーションを削除。各種Controllerのアクセス修飾子整理とあわせて、Router自体のリファクタリングを一旦完了とする
  - （ #279  HTTP methodの厳格化はControllerの大規模リファクタ（分割）が必要なので、バリデーションをControllerにいれる予定）

作業時間  7h