### PR TITLE
アクセス時のHTTPリクエストmethodの厳格化 #279

### DIFF
--- a/app/src/Web/Controller/Admin/BlogSettingsController.php
+++ b/app/src/Web/Controller/Admin/BlogSettingsController.php
@@ -10,7 +10,6 @@ use Fc2blog\Web\Request;
 
 class BlogSettingsController extends AdminController
 {
-
     /**
      * コメント編集
      * @param Request $request
@@ -78,7 +77,7 @@ class BlogSettingsController extends AdminController
         $blog_id = $this->getBlogIdFromSession();
 
         // 初期表示時に編集データの取得&設定
-        if (!$request->get('blog_setting') || !$request->isValidSig()) {
+        if (!$request->get('blog_setting') || !$request->isValidPost()) {
             $blog_setting = $blog_settings_model->findByBlogId($blog_id);
             $request->set('blog_setting', $blog_setting);
             return $this->get('template_path');
@@ -112,6 +111,4 @@ class BlogSettingsController extends AdminController
 
         return $this->get('template_path');
     }
-
 }
-

--- a/app/src/Web/Controller/Admin/BlogsController.php
+++ b/app/src/Web/Controller/Admin/BlogsController.php
@@ -12,7 +12,6 @@ use Tuupola\Base62Proxy;
 
 class BlogsController extends AdminController
 {
-
     /**
      * 一覧表示
      * @param Request $request
@@ -20,6 +19,8 @@ class BlogsController extends AdminController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // ブログの一覧取得
         $options = [
             'where' => 'user_id=?',
@@ -53,6 +54,8 @@ class BlogsController extends AdminController
         if (!$request->get('blog') || !$request->isValidSig()) {
             return 'admin/blogs/create.twig';
         }
+
+        if (!$request->isPost()) return $this->error400();
 
         $blogs_model = new BlogsModel();
 
@@ -91,7 +94,7 @@ class BlogsController extends AdminController
         $this->set('tab', 'blog_edit');
 
         // 初期表示時に編集データの設定
-        if (!$request->get('blog') || !$request->isValidSig()) {
+        if (!$request->get('blog') || !$request->isValidPost()) {
             if (!$blog = $blogs_model->findById($blog_id)) {
                 $this->redirect($request, ['action' => 'index']);
             }
@@ -100,6 +103,8 @@ class BlogsController extends AdminController
         }
 
         // 更新処理
+        if (!$request->isPost()) return $this->error400();
+
         $white_list = ['name', 'introduction', 'nickname', 'timezone', 'blog_password', 'open_status', 'ssl_enable', 'redirect_status_code'];
         $errors['blog'] = $blogs_model->validate(
         // バリデーションのために、blog_idを引き回している。バリデーションを作り変えたい
@@ -131,9 +136,12 @@ class BlogsController extends AdminController
     /**
      * ブログの切り替え
      * @param Request $request
+     * @return string
      */
-    public function choice(Request $request)
+    public function choice(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->get('blog_id');
 
         // 切り替え先のブログの存在チェック
@@ -142,6 +150,7 @@ class BlogsController extends AdminController
             $this->setBlog($blog);
         }
         $this->redirect($request, $request->baseDirectory);   // トップページへリダイレクト
+        return "";
     }
 
     /**
@@ -151,9 +160,10 @@ class BlogsController extends AdminController
      */
     public function delete(Request $request): string
     {
+
         $this->set('tab', 'blog_delete');
         // 退会チェック
-        if (!$request->get('blog.delete') || !$request->isValidSig()) {
+        if (!$request->get('blog.delete') || !$request->isValidPost()) {
             return 'admin/blogs/delete.twig';
         }
 
@@ -174,6 +184,4 @@ class BlogsController extends AdminController
         $this->redirect($request, ['action' => 'index']);
         return 'admin/blogs/delete.twig'; // 到達しないはずである
     }
-
 }
-

--- a/app/src/Web/Controller/Admin/CommentsController.php
+++ b/app/src/Web/Controller/Admin/CommentsController.php
@@ -12,7 +12,6 @@ use Fc2blog\Web\Request;
 
 class CommentsController extends AdminController
 {
-
     /**
      * 一覧表示
      * @param Request $request
@@ -20,6 +19,8 @@ class CommentsController extends AdminController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $comments_model = new CommentsModel();
         $blog_id = $this->getBlogIdFromSession();
 
@@ -135,6 +136,7 @@ class CommentsController extends AdminController
      */
     public function approval(Request $request)
     {
+        // TODO POST化、Sigチェック
         $comments_model = Model::load('Comments');
 
         $id = $request->get('id');

--- a/app/src/Web/Controller/Admin/CommonController.php
+++ b/app/src/Web/Controller/Admin/CommonController.php
@@ -20,9 +20,12 @@ class CommonController extends AdminController
     /**
      * 言語設定変更
      * @param Request $request
+     * @return string
      */
-    public function lang(Request $request)
+    public function lang(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // 言語の設定
         $lang = $request->get('lang');
         if (Config::get('LANGUAGES.' . $lang)) {
@@ -36,15 +39,19 @@ class CommonController extends AdminController
             $url .= '?' . $device_name;
         }
         $this->redirectBack($request, $url);
+        return "";
     }
 
     /**
      * デバイス変更
      * @param Request $request
+     * @return string
      * @noinspection PhpUnused
      */
-    public function device_change(Request $request)
+    public function device_change(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // デバイスの設定
         $device_type = 0;
         $device = $request->get('device');
@@ -62,14 +69,18 @@ class CommonController extends AdminController
 
         Cookie::set($request, 'device', $device_type);
         $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index'));
+        return "";
     }
 
     /**
      * /admin/ ブログの設定より初期表示ページを決定し、リダイレクト
      * @param Request $request
+     * @return string
      */
-    public function index(Request $request)
+    public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // 設定読み込みをしてリダイレクト
         if (is_string($blog_id = $this->getBlogIdFromSession())) {
             $blog_settings = new BlogSettingsModel();
@@ -81,24 +92,29 @@ class CommonController extends AdminController
             switch ($setting['start_page']) {
                 case Config::get('BLOG.START_PAGE.ENTRY'):
                     $this->redirect($request, ['controller' => 'Entries', 'action' => 'create']);
-                    break;
+                    return ""; // break;
 
                 case Config::get('BLOG.START_PAGE.NOTICE'):
                 default:
                     $this->redirect($request, ['controller' => 'Common', 'action' => 'notice']);
-                    break;
+                    return ""; // break;
             }
         } else { // 設定なし
             $this->redirect($request, ['controller' => 'Common', 'action' => 'notice']);
+            return "";
         }
+
     }
 
     /**
      * お知らせ一覧画面
+     * @param Request $request
      * @return string
      */
-    public function notice(/*Request $request*/): string
+    public function notice(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $this->getBlogIdFromSession();
 
         $comments_model = new CommentsModel();
@@ -126,6 +142,7 @@ class CommonController extends AdminController
         switch ($state) {
             default:
             case 0:
+                if (!$request->isGet()) return $this->error400();
                 // 環境チェック確認
                 $this->set('temp_dir', Config::get('TEMP_DIR'));
                 $this->set('www_upload_dir', Config::get('WWW_UPLOAD_DIR'));
@@ -180,6 +197,7 @@ class CommonController extends AdminController
                 return 'admin/common/install.twig';
 
             case 1:
+                if (!$request->isGet()) return $this->error400();
                 // 各種初期設定、DB テーブル作成、ディレクトリ作成
 
                 // フォルダの作成
@@ -264,6 +282,7 @@ class CommonController extends AdminController
                 }
 
                 // 以下はユーザー登録実行
+                if (!$request->isPost()) return $this->error400();
                 $users_model = new UsersModel();
                 $blogs_model = new BlogsModel();
 
@@ -301,6 +320,7 @@ class CommonController extends AdminController
 
             case 3:
                 // 完了画面
+                if (!$request->isGet()) return $this->error400();
 
                 // 完了画面表示と同時に、インストール済みロックファイルの生成
                 file_put_contents($this->getInstalledLockFilePath(), "This is installed check lockfile.\nThe blog already installed. if you want re-enable installer, please delete this file.");

--- a/app/src/Web/Controller/Admin/EntriesController.php
+++ b/app/src/Web/Controller/Admin/EntriesController.php
@@ -16,7 +16,6 @@ use Fc2blog\Web\Request;
 
 class EntriesController extends AdminController
 {
-
     /**
      * 一覧表示
      * @param Request $request
@@ -24,6 +23,8 @@ class EntriesController extends AdminController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $entries_model = new EntriesModel();
         $blog_id = $this->getBlogIdFromSession();
 
@@ -161,6 +162,7 @@ class EntriesController extends AdminController
         }
 
         // 新規登録処理
+        if (!$request->isPost()) return $this->error400();
         $errors = [];
         $whitelist_entry = ['title', 'body', 'extend', 'open_status', 'password', 'auto_linefeed', 'comment_accepted', 'posted_at'];
         $errors['entry'] = $entries_model->validate($request->get('entry'), $entry_data, $whitelist_entry);
@@ -239,6 +241,7 @@ class EntriesController extends AdminController
         }
 
         // 更新処理
+        if (!$request->isPost()) return $this->error400();
         $errors = [];
         $whitelist_entry = ['title', 'body', 'extend', 'open_status', 'password', 'auto_linefeed', 'comment_accepted', 'posted_at'];
         $errors['entry'] = $entries_model->validate($request->get('entry'), $entry_data, $whitelist_entry);
@@ -291,7 +294,7 @@ class EntriesController extends AdminController
      */
     public function delete(Request $request)
     {
-        if ($request->isValidSig()) {
+        if ($request->isValidPost()) {
             // 削除処理
             if (Model::load('Entries')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession()))
                 $this->setInfoMessage(__('I removed the entry'));
@@ -307,6 +310,8 @@ class EntriesController extends AdminController
      */
     public function ajax_media_load(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         if ($this->isInvalidAjaxRequest($request)) {
             return $this->error403();
         }
@@ -341,6 +346,4 @@ class EntriesController extends AdminController
 
         return 'admin/entries/ajax_media_load.twig';
     }
-
 }
-

--- a/app/src/Web/Controller/Admin/FilesController.php
+++ b/app/src/Web/Controller/Admin/FilesController.php
@@ -11,7 +11,6 @@ use Fc2blog\Web\Request;
 
 class FilesController extends AdminController
 {
-
     /**
      * 一覧表示 /admin/files/upload からPartial読み込み
      * @param Request $request
@@ -87,6 +86,7 @@ class FilesController extends AdminController
      */
     public function upload(Request $request): string
     {
+        // TODO uploadと一覧の分離
         $files_model = new FilesModel();
         $blog_id = $this->getBlogIdFromSession();
 
@@ -95,6 +95,11 @@ class FilesController extends AdminController
 
         // アップロード時処理
         if ($request->file('file')) {
+            if (!$request->isValidSig()) {
+                $request = new Request();
+                $this->redirect($request, ['action' => 'upload']);
+            }
+
             // 新規登録処理
             $errors = [];
             $errors['file'] = $files_model->insertValidate($request->file('file'), $request->get('file'), $data_file);
@@ -115,6 +120,7 @@ class FilesController extends AdminController
 
                     $this->setInfoMessage(__('I have completed the upload of files'));
                     $this->redirect($request, array('action' => 'upload')); // アップロード成功
+                    return "";
                 }
             }
             // 拡張子チェックエラーはファイルが指定されていない時には表示不要と思われるので、unset
@@ -220,6 +226,7 @@ class FilesController extends AdminController
         }
 
         // 新規登録処理
+        // TODO 修正処理とHTMLレスポンスの分離
         $errors = [];
         $errors['file'] = $files_model->updateValidate($request->file('file'), $request->get('file'), $file, $data_file);
         if (empty($errors['file'])) {

--- a/app/src/Web/Controller/Admin/PasswordResetController.php
+++ b/app/src/Web/Controller/Admin/PasswordResetController.php
@@ -14,6 +14,8 @@ class PasswordResetController extends AdminController
     /** @noinspection PhpUnused */
     public function requestForm(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // 未ログインだとSigが生成されていないため、ここで生成する。
         // 複数個ウインドウを開くとsigがエラーになるが、ありえないかと思われる。
         $request->generateNewSig();

--- a/app/src/Web/Controller/Admin/PasswordResetController.php
+++ b/app/src/Web/Controller/Admin/PasswordResetController.php
@@ -61,6 +61,8 @@ class PasswordResetController extends AdminController
     /** @noinspection PhpUnused */
     public function resetForm(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $token_str = $request->get('token');
         $token = PasswordResetTokenService::getByToken($token_str);
 

--- a/app/src/Web/Controller/Admin/SessionController.php
+++ b/app/src/Web/Controller/Admin/SessionController.php
@@ -20,6 +20,8 @@ class SessionController extends AdminController
      */
     public function login(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         if ($this->isLogin()) {
             // ログイン済みならトップページへリダイレクト
             $this->redirect($request, $request->baseDirectory);
@@ -97,6 +99,8 @@ class SessionController extends AdminController
      */
     public function mailLogin(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // get&check login token
         $token_str = $request->get('token');
 
@@ -133,6 +137,8 @@ class SessionController extends AdminController
      */
     public function logout(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // TODO refactoring
         if ($this->isLogin()) {
             Session::destroy($request);

--- a/app/src/Web/Controller/Admin/SystemUpdateController.php
+++ b/app/src/Web/Controller/Admin/SystemUpdateController.php
@@ -10,10 +10,10 @@ use LogicException;
 
 class SystemUpdateController extends AdminController
 {
-    /** @noinspection PhpUnusedParameterInspection */
     public function index(Request $request): string
     {
         // TODO unit test
+        if (!$request->isGet()) return $this->error400();
 
         $release_list = SystemUpdateModel::getReleaseInfo();
         $this->set('release_list', $release_list);
@@ -25,6 +25,7 @@ class SystemUpdateController extends AdminController
     public function update(Request $request): string
     {
         // TODO unit test
+        if (!$request->isPost()) return $this->error400();
 
         if (!$request->isValidSig()) {
             $this->setWarnMessage(__("Request failed: invalid sig, please retry."));
@@ -54,6 +55,4 @@ class SystemUpdateController extends AdminController
 
         throw new LogicException("must be redirect");
     }
-
 }
-

--- a/app/src/Web/Controller/Admin/TagsController.php
+++ b/app/src/Web/Controller/Admin/TagsController.php
@@ -10,7 +10,6 @@ use Fc2blog\Web\Request;
 
 class TagsController extends AdminController
 {
-
     /**
      * 一覧表示
      * @param Request $request
@@ -18,6 +17,8 @@ class TagsController extends AdminController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $tags_model = new TagsModel();
         $blog_id = $this->getBlogIdFromSession();
 
@@ -102,6 +103,7 @@ class TagsController extends AdminController
         }
 
         // 更新処理
+        if (!$request->isPost()) return $this->error400();
         $tag_request = $request->get('tag');
         $tag_request['id'] = $id;
         $tag_request['blog_id'] = $blog_id;
@@ -132,6 +134,7 @@ class TagsController extends AdminController
      */
     public function delete(Request $request)
     {
+        // TODO POST化
         if ($request->isValidSig()) {
             // 削除処理
             if (Model::load('Tags')->deleteByIdsAndBlogId($request->get('id'), $this->getBlogIdFromSession())) {
@@ -148,6 +151,4 @@ class TagsController extends AdminController
         }
         $this->redirectBack($request, array('action' => 'index'));
     }
-
 }
-

--- a/app/src/Web/Controller/Admin/UsersController.php
+++ b/app/src/Web/Controller/Admin/UsersController.php
@@ -19,6 +19,8 @@ class UsersController extends AdminController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         if (!$this->isAdmin()) {
             return $this->error404();
         }
@@ -63,6 +65,7 @@ class UsersController extends AdminController
         $blogs_model = Model::load('Blogs');
 
         // ユーザーとブログの新規登録処理
+        if (!$request->isPost()) return $this->error400();
         $errors = array();
         $errors['user'] = $users_model->registerValidate($request->get('user'), $user_data, array('login_id', 'password'));
         $errors['blog'] = $blogs_model->validate($request->get('blog'), $blog_data, array('id', 'name', 'nickname'));
@@ -106,6 +109,7 @@ class UsersController extends AdminController
         }
 
         // 更新処理
+        if (!$request->isPost()) return $this->error400();
         $errors = [];
         $white_list = ['password', 'login_blog_id'];
         $errors['user'] = $users_model->updateValidate($request->get('user'), $data_user, $white_list);
@@ -139,6 +143,7 @@ class UsersController extends AdminController
         }
 
         // 削除処理
+        if (!$request->isPost()) return $this->error400();
         Model::load('Users')->deleteById($this->getUserId());
         $this->setInfoMessage(__('Was completed withdrawal'));
         if ($this->isLogin()) {

--- a/app/src/Web/Controller/Controller.php
+++ b/app/src/Web/Controller/Controller.php
@@ -328,6 +328,13 @@ abstract class Controller
         return 'user/common/error400.twig';
     }
 
+    // 500 BadRequest
+    protected function error500(): string
+    {
+        $this->setStatusCode(500);
+        return 'user/common/error500.twig';
+    }
+
     public function getOutput(): string
     {
         if (!defined("THIS_IS_TEST")) {

--- a/app/src/Web/Controller/User/BlogsController.php
+++ b/app/src/Web/Controller/User/BlogsController.php
@@ -19,6 +19,8 @@ class BlogsController extends UserController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog = (new BlogsModel())->findByRandom();
         if (empty($blog)) {
             return $this->error404();
@@ -34,6 +36,8 @@ class BlogsController extends UserController
      */
     public function feed(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blogs_model = new BlogsModel();
         $blog = $blogs_model->findById($request->getBlogId());
         if (empty($blog)) {

--- a/app/src/Web/Controller/User/CommonController.php
+++ b/app/src/Web/Controller/User/CommonController.php
@@ -20,9 +20,12 @@ class CommonController extends UserController
     /**
      * 言語設定変更
      * @param Request $request
+     * @return string
      */
-    public function lang(Request $request)
+    public function lang(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // 言語の設定
         $lang = $request->get('lang');
         if (Config::get('LANGUAGES.' . $lang)) {
@@ -31,14 +34,18 @@ class CommonController extends UserController
 
         // 元のURLに戻す
         $this->redirectBack($request, '/');
+        return "";
     }
 
     /**
      * デバイス変更
      * @param Request $request
+     * @return string
      */
-    public function device_change(Request $request)
+    public function device_change(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // デバイスの設定
         $device_type = 0;
         $device = $request->get('device');
@@ -56,15 +63,20 @@ class CommonController extends UserController
 
         Cookie::set($request, 'device', $device_type);
         $this->redirectBack($request, array('controller' => 'entries', 'action' => 'index', 'blog_id' => $request->getBlogId()));
+        return "";
     }
 
     const CAPTCHA_TOKEN_KEY_NAME = 'token';
+
     /**
      * 画像認証
      * @param Request $request
+     * @return string
      */
-    public function captcha(Request $request)
+    public function captcha(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $size_x = 200;
         $size_y = 40;
         // 自動テスト用に"DEBUG_FORCE_CAPTCHA_KEY"環境変数で、Captchaキーの固定機能
@@ -96,6 +108,7 @@ class CommonController extends UserController
         } catch (Exception $e) {
             throw new RuntimeException("drawNumber failed. {$e->getMessage()} {$e->getFile()}:{$e->getLine()}");
         }
+        return "";
     }
 
     /**
@@ -117,6 +130,8 @@ class CommonController extends UserController
      */
     public function thumbnail(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->get('blog_id');
         $id = $request->get('id');
         $ext = $request->get('ext');

--- a/app/src/Web/Controller/User/EntriesController.php
+++ b/app/src/Web/Controller/User/EntriesController.php
@@ -88,6 +88,8 @@ class EntriesController extends UserController
      */
     public function index(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->getBlogId();
         if (!$blog_id) {
             Log::notice("missing blog_id parameter. redirect to top. blog_id: {$blog_id}");
@@ -112,6 +114,8 @@ class EntriesController extends UserController
      */
     public function search(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $where = 'blog_id=?';
         $params = array($request->getBlogId());
 
@@ -139,6 +143,8 @@ class EntriesController extends UserController
      */
     public function category(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->getBlogId();
         $category_id = $request->get('cat');
 
@@ -173,6 +179,8 @@ class EntriesController extends UserController
      */
     public function tag(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // タグ検索
         $blog_id = $request->getBlogId();
         $tag_name = $request->get('tag');
@@ -206,6 +214,8 @@ class EntriesController extends UserController
      */
     public function date(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // 開始日付と終了日付の計算
         preg_match('/^([0-9]{4})([0-9]{2})?([0-9]{2})?$/', $request->get('date'), $matches);
         $dates = $matches + array('', date('Y'), 0, 0);
@@ -231,6 +241,8 @@ class EntriesController extends UserController
      */
     public function archive(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         // 記事一覧データ設定
         $options = array(
             'fields' => array(
@@ -266,7 +278,7 @@ class EntriesController extends UserController
             return $this->error404();
         }
 
-        // 記事のプレビュー
+        // 記事のプレビュー(POST)
         if ($request->get('entry')) {
             return $this->preview_entry($request);
         }
@@ -297,6 +309,8 @@ class EntriesController extends UserController
      */
     private function preview_fc2_template(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->getBlogId();
 
         // 記事一覧データ設定
@@ -334,6 +348,8 @@ class EntriesController extends UserController
      */
     private function preview_template(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->getBlogId();
 
         // 記事一覧データ設定
@@ -371,6 +387,8 @@ class EntriesController extends UserController
      */
     private function preview_plugin(Request $request): string
     {
+        if (!$request->isPost()) return $this->error400();
+
         $blog_id = $request->getBlogId();
 
         // プラグインのプレビュー情報取得
@@ -457,6 +475,8 @@ class EntriesController extends UserController
      */
     private function preview_entry(Request $request): string
     {
+        if (!$request->isPost()) return $this->error400();
+
         $blog_id = $request->getBlogId();
 
         // DBの代わりにリクエストから取得
@@ -509,6 +529,8 @@ class EntriesController extends UserController
      */
     public function view(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->getBlogId();
         $entry_id = (int)$request->get('id');
 
@@ -641,6 +663,8 @@ class EntriesController extends UserController
      */
     public function plugin(Request $request): string
     {
+        if (!$request->isGet()) return $this->error400();
+
         $blog_id = $request->getBlogId();
         $id = $request->get('id');
 
@@ -657,6 +681,7 @@ class EntriesController extends UserController
      * 記事のパスワード認証
      * @param Request $request
      * @return string
+     * TODO POST化
      */
     public function password(Request $request): string
     {
@@ -702,7 +727,8 @@ class EntriesController extends UserController
         }
 
         // 認証処理
-        if ($request->get('blog')) {
+        // TODO Sigがない
+        if ($request->get('blog') && $request->isPost()) {
             if (password_verify($request->get('blog.password'), $blog->blog_password)) {
                 Session::set($this->getBlogPasswordKey($blog->id), true);
                 $this->set('auth_success', true); // for testing.
@@ -723,6 +749,8 @@ class EntriesController extends UserController
      */
     public function comment_regist(Request $request): string
     {
+        if (!$request->isPost()) return $this->error400();
+
         $blog_id = $request->getBlogId();
 
         // ブログの設定情報取得(captchaの使用可否で画面切り替え)
@@ -854,7 +882,7 @@ class EntriesController extends UserController
         $this->set('edit_entry', $entry);
 
         // 初期表示処理
-        if (!$request->get('comment.id')) {
+        if (!$request->get('comment.id') && $request->isGet()) {
             $this->set('edit_comment', $comment);
 
             // FC2用のテンプレートで表示
@@ -863,7 +891,11 @@ class EntriesController extends UserController
             return $this->getFc2TemplatePath($blog_id);
         }
 
+        // これ以後はPOSTでのみ処理を許可する
+        if (!$request->isPost()) return $this->error400();
+
         // 削除ボタンを押された場合の処理(comment_deleteに処理を移譲)
+        // TODO sig
         if ($request->get('comment.delete')) {
             return $this->comment_delete($request);
         }
@@ -913,6 +945,8 @@ class EntriesController extends UserController
      */
     public function comment_delete(Request $request): string
     {
+        if (!$request->isPost()) return $this->error400();
+
         $comments_model = new CommentsModel();
 
         $blog_id = $request->getBlogId();

--- a/app/src/Web/Fc2BlogTemplate.php
+++ b/app/src/Web/Fc2BlogTemplate.php
@@ -45,7 +45,7 @@ class Fc2BlogTemplate
                 // 自動改行処理
                 if ($value['auto_linefeed'] == Config::get('ENTRY.AUTO_LINEFEED.USE')) {
                     $data['entries'][$key]['body'] = nl2br($value['body']);
-                    $data['entries'][$key]['extend'] = nl2br($value['extend']);
+                    $data['entries'][$key]['extend'] = nl2br((string)$value['extend']);
                 }
 
                 // topentry_enc_* 系タグの生成

--- a/app/src/Web/Request.php
+++ b/app/src/Web/Request.php
@@ -304,6 +304,15 @@ class Request
     }
 
     /**
+     * リクエストメソッドがPOSTか判定を行う
+     * @return bool
+     */
+    public function isPost(): bool
+    {
+        return $this->method === 'POST';
+    }
+
+    /**
      * @param string $key
      * @return bool
      */
@@ -346,7 +355,7 @@ class Request
      */
     public function isValidPost(): bool
     {
-        return $this->method === "POST" && $this->isValidSig();
+        return $this->isPost() && $this->isValidSig();
     }
 
     public function isValidSig(): bool

--- a/app/twig_templates/admin/blog_plugins/index.twig
+++ b/app/twig_templates/admin/blog_plugins/index.twig
@@ -70,6 +70,7 @@
         var blog_plugins = {{ blog_plugin_json|json_encode()|raw }};
         $(function () {
             // 表示切り替え
+            {# TODO POST methodに変更 #}
             $('input[type=checkbox][name="blog_plugin[display]"]').on('click', function () {
                 $.ajax({
                     url: common.fwURL('blog_plugins', 'display_change', {

--- a/app/twig_templates/admin/blog_templates/fc2_index.twig
+++ b/app/twig_templates/admin/blog_templates/fc2_index.twig
@@ -19,6 +19,7 @@
                 <tr>
                     <td class="btn">
                         <a class="admin_common_btn create_btn" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, fc2_id:template.id, device_type: req.get('device_type')}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
+                        {# TODO  blog_templates createのPOST化 #}
                         <a class="admin_common_btn create_btn" href="{{ url(req, 'blog_templates', 'create', {fc2_id: template.id, device_type:req.get('device_type'), sig: sig}) }}">{{ _('Download') }}</a>
                     </td>
                 </tr>

--- a/app/twig_templates/admin/blog_templates/fc2_view_sp.twig
+++ b/app/twig_templates/admin/blog_templates/fc2_view_sp.twig
@@ -17,6 +17,7 @@
                 <a class="btn_contents touch" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, fc2_id: template.id, device_type: req.get('device_type')}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
             </p>
             <p>
+                {# TODO  blog_templates downloadのPOST化 #}
                 <a class="btn_contents touch" href="{{ url(req, 'blog_templates', 'download', {fc2_id: template.id, device_type: req.get('device_type'), sig: sig}) }}">{{ _('Download') }}</a>
             </p>
         </div>

--- a/app/twig_templates/admin/blog_templates/index.twig
+++ b/app/twig_templates/admin/blog_templates/index.twig
@@ -32,6 +32,7 @@
                     {% endif %}
                     {% if not inArray(blog_template.id, template_ids) %}
                         <td class="center">
+                            {# TODO 適用処理のPOST化 #}
                             <a href="{{ url(req, 'BlogTemplates', 'apply', { 'id': blog_template.id, 'sig': sig}) }}" onclick="return confirm('{{ _('Are you sure you want to apply this template?') }}')">{{ _('Apply') }}</a>
                         </td>
                     {% endif %}
@@ -43,6 +44,7 @@
                             &nbsp;
                         {% endif %}
                         {% if not inArray(blog_template.id, template_ids) %}
+                            {# TODO 削除処理のPOST化 #}
                             <a href="{{ url(req, 'BlogTemplates', 'delete', { 'id': blog_template.id, 'sig': sig}) }}" onclick="return confirm('{{ _('Are you sure you want to delete?') }}');">{{ _('Delete') }}</a>
                         {% endif %}
                     </td>

--- a/app/twig_templates/admin/blog_templates/index_sp.twig
+++ b/app/twig_templates/admin/blog_templates/index_sp.twig
@@ -62,6 +62,7 @@
                     return;
                 }
                 if (confirm('{{ _('Are you sure you want to delete?') }}')) {
+                    {# TODO 削除処理のPOST化 #}
                     location.href = common.fwURL('blog_templates', 'delete', {id: id, sig: "{{ sig }}"});
                 }
             });

--- a/app/twig_templates/admin/comments/ajax_reply.twig
+++ b/app/twig_templates/admin/comments/ajax_reply.twig
@@ -35,7 +35,7 @@
                 {{ _('Published') }}
             {% endif %}
             {% if comment.open_status == comment_open_status_pending %}
-                {{ _('Approval pending') }} &raquo; <a href="{{ url(req, 'comments', 'approval', {id: comment.id}) }}" onclick="reply.approval({{ comment.id }}); return false;" id="sys-comment-approval">{{ _('Approval') }}</a>
+                {{ _('Approval pending') }} &raquo; <a {# TODO hrefの必要ないのでは？ #}href="{{ url(req, 'comments', 'approval', {id: comment.id}) }}" onclick="reply.approval({{ comment.id }}); return false;" id="sys-comment-approval">{{ _('Approval') }}</a>
             {% endif %}
             {% if comment.open_status == comment_open_status_private %}
                 {{ _('Only exposed administrator') }}

--- a/app/twig_templates/admin/comments/index.twig
+++ b/app/twig_templates/admin/comments/index.twig
@@ -77,7 +77,7 @@
                                 <span class="published">{{ _('Published') }}</span>
                             {% endif %}
                             {% if comment.open_status == comment_open_status_pending %}
-                                <span class="approval"><a href="{{ url(req, 'comments', 'approval', {id: comment.id}) }}" onclick="reply.approval({{ comment.id }}); return false;">{{ _('Approval') }}</a></span>
+                                <span class="approval"><a {# TODO hrefの必要ないのでは？ #}href="{{ url(req, 'comments', 'approval', {id: comment.id}) }}" onclick="reply.approval({{ comment.id }}); return false;">{{ _('Approval') }}</a></span>
                             {% endif %}
                             {% if comment.open_status == comment_open_status_private %}
                                 <span class="private">{{ _('Only exposed administrator') }}</span>

--- a/app/twig_templates/admin/comments/reply_sp.twig
+++ b/app/twig_templates/admin/comments/reply_sp.twig
@@ -45,8 +45,8 @@
     <div class="btn_area">
         {% if comment.open_status == comment_open_status_pending %}
             <div class="btn">
-                <a href="{{ url(req, 'comments', 'approval', {id: comment.id, back_url: request.get('back_url')}) }}"
-                   onclick="return confirm('{{ _('Are you sure you want to be approved?') }}');" class="btn_contents positive touch"><i class="check_icon btn_icon"></i>{{ _('I moderate comments') }}</a>
+                <a {# TODO POST化 #} href="{{ url(req, 'comments', 'approval', {id: comment.id, back_url: request.get('back_url')}) }}"
+                                    onclick="return confirm('{{ _('Are you sure you want to be approved?') }}');" class="btn_contents positive touch"><i class="check_icon btn_icon"></i>{{ _('I moderate comments') }}</a>
             </div>
         {% endif %}
         <ul class="btn_area_inner">

--- a/app/twig_templates/admin/system_update/index.twig
+++ b/app/twig_templates/admin/system_update/index.twig
@@ -63,7 +63,7 @@
                         <p>{{ release.body|nl2br }}</p>
                     </td>
                     <td class="op_col">
-                        <form action="{{ url(request, "SystemUpdate", "update", {sig:sig}) }}"
+                        <form action="{{ url(request, "SystemUpdate", "update", {sig:sig}) }}" method="post"
                               onsubmit="return confirm('{{ _('CAUTION: System will be update. Did you make backup?') }}')">
                             <input type="hidden" name="version" value="{{ release.tag_name }}">
                             <input type="hidden" name="sig" value="{{ sig }}">

--- a/app/twig_templates/admin/tags/index.twig
+++ b/app/twig_templates/admin/tags/index.twig
@@ -43,6 +43,7 @@
                     <td><a href="{{ blogUrl(req, blog.id) }}/?tag={{ tag.name }}" target="_blank">{{ tag.name }}</a></td>
                     <td>{{ tag.count }}</td>
                     <td class="center s_cell"><a href="{{ url(req, 'Tags', 'edit', {id: tag.id}) }}">{{ _('Edit') }}</a></td>
+                    {# TODO deleteをPOST化 #}
                     <td class="center s_cell"><a href="{{ url(req, 'Tags', 'delete', {id: tag.id, sig: sig}) }}" onclick="return confirm('{{ _('Are you sure you want to delete?') }}');">{{ _('Delete') }}</a></td>
                 </tr>
             {% endfor %}

--- a/app/twig_templates/user/common/error400.twig
+++ b/app/twig_templates/user/common/error400.twig
@@ -1,5 +1,5 @@
 {% extends 'user/layouts/default.twig' %}
-{% block title %}{{ _('403 Forbidden.') }}{% endblock %}
+{% block title %}{{ _('400 BadRequest.') }}{% endblock %}
 
 {% block content %}
     <h1>{{ _('400 BadRequest.') }}</h1>

--- a/app/twig_templates/user/common/error500.twig
+++ b/app/twig_templates/user/common/error500.twig
@@ -1,0 +1,6 @@
+{% extends 'user/layouts/default.twig' %}
+{% block title %}{{ _('500 Internal Server Error.') }}{% endblock %}
+
+{% block content %}
+    <h1>{{ _('500 Internal Server Error.') }}</h1>
+{% endblock %}

--- a/app/twig_templates/user/common/error500_sp.twig
+++ b/app/twig_templates/user/common/error500_sp.twig
@@ -1,0 +1,6 @@
+{% extends 'user/layouts/default_sp.twig' %}
+{% block title %}{{ _('500 Internal Server Error.') }}{% endblock %}
+
+{% block content %}
+    <header><h1 class="in_menu sh_heading_main_b"><span class="h1_title">{{ _('500 Internal Server Error.') }}</span></h1></header>
+{% endblock %}

--- a/tests/App/Controller/Admin/Common/InstallTest.php
+++ b/tests/App/Controller/Admin/Common/InstallTest.php
@@ -104,7 +104,7 @@ class InstallTest extends TestCase
         $this->resetSession();
         $this->resetCookie();
 
-        $r = $this->reqPostBeRedirect("/admin/common/install", ['state' => 1]);
+        $r = $this->reqGetBeRedirect("/admin/common/install", ['state' => 1]);
         $this->assertEquals('/admin/common/install?state=2', $r->redirectUrl);
     }
 

--- a/tests/App/Controller/Admin/Entries/DeleteTest.php
+++ b/tests/App/Controller/Admin/Entries/DeleteTest.php
@@ -32,7 +32,7 @@ class DeleteTest extends TestCase
 
         $sig = $this->getSig();
 
-        $r = $this->reqGetBeRedirect("/admin/entries/delete", ["id" => $some_entry['id'], "sig" => $sig]);
+        $r = $this->reqPostBeRedirect("/admin/entries/delete", ["id" => $some_entry['id'], "sig" => $sig]);
 
         $this->assertEquals("/admin/entries/index", $r->redirectUrl);
 
@@ -66,7 +66,7 @@ class DeleteTest extends TestCase
             'sig' => $sig
         ];
 
-        $r = $this->reqGetBeRedirect("/admin/entries/delete", $request_data);
+        $r = $this->reqPostBeRedirect("/admin/entries/delete", $request_data);
         $this->assertEquals("/admin/entries/index", $r->redirectUrl);
 
         $c = $this->reqGet("/admin/entries/index");

--- a/tests/App/Controller/Admin/Tags/EditTest.php
+++ b/tests/App/Controller/Admin/Tags/EditTest.php
@@ -55,7 +55,7 @@ class EditTest extends TestCase
             'tag' => ['name' => "testtagname"]
         ];
 
-        $r = $this->reqGetBeRedirect("/admin/tags/edit", $request_data);
+        $r = $this->reqPostBeRedirect("/admin/tags/edit", $request_data);
         $this->assertEquals('/admin/tags/index', $r->redirectUrl);
 
         $c = $this->reqGet("/admin/tags/index");


### PR DESCRIPTION
ref: #279 

- User系コントローラーで各ControllerのHttp method確認を追加
  - Blogs
  - Common
  - Entries
  - （これですべて対応完了と思われる
- Admin系コントローラーで各ControllerのHttp method確認を追加
  - Blogplugins
  - Blogs
  - BlogSettings
  - Categories
  - Comments
  - Common
  - Files
  - PasswordReset
  - Session
  - SystemUpdate
  - Tags
  - Users
  - （Entriesは事前に対応済み、これですべて対応完了と思われる
- 明確ではなかった箇所で、明確化したところテストが壊れたので修正
- 一部、Sigチェック不足や、POSTであるべき所がGETである箇所を発見したのでISSUEやTODO作成。追って直していく。

## Note

- これで各ActionのHttp Methodが固定・確認できたので、安全・安定性と見通しが向上した。
- 将来的には「アクション実行の手前」で、Http Methodを固定したい
  - 完了すれば、AdhocなSig確認でなく、「POST（更新処理）はすべてSig確認」などを前段で入れるなどができるようになる。
- ただし、現状は各アクションはGET/POSTが混在する前提で書かれており（参照と、更新がおなじアクションに記述され、引数で分岐している）アクションのリファクタリングと分割を予定
- GET+Sig有りな更新処理を洗い出したので、これらを対応していく。

作業時間 6h
