### PR TITLE
プラグイン並べ替え画面機能の修正 #322

### DIFF
--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -36,7 +36,7 @@ class BlogPluginsController extends AdminController
         $blog_plugin_json = [];
         foreach ($category_blog_plugins as $blog_plugins) {
             foreach ($blog_plugins as $blog_plugin) {
-                $json[] = array(
+                $blog_plugin_json[] = array(
                     'id' => $blog_plugin['id'],
                     'category' => $blog_plugin['category'],
                     'title' => $blog_plugin['title'],

--- a/app/twig_templates/admin/layouts/default.twig
+++ b/app/twig_templates/admin/layouts/default.twig
@@ -13,6 +13,7 @@
     {% endif %}
 
     <script type="text/javascript" src="/assets/js/jquery.js"></script>
+    <script type="text/javascript" src="/assets/js/jquery-ui/jquery-ui.min.js"></script>
 
     <script type="text/javascript" src="/assets/js/common_design.js"></script>
     <script type="text/javascript" src="/assets/js/common.js"></script>


### PR DESCRIPTION
ref #322 

- プラグイン並べ替え画面に渡されるJSONが空になっていた
- jquery-uiが必要な画面だが、確認不足で外されていた（管理画面グローバルに読み込みを戻した）

## SS
![image](https://user-images.githubusercontent.com/870716/121765404-8953ee00-cb85-11eb-9c10-689c584e3fe2.png)
![image](https://user-images.githubusercontent.com/870716/121765410-9375ec80-cb85-11eb-983e-ee54ebd5e64e.png)
![image](https://user-images.githubusercontent.com/870716/121765414-9e308180-cb85-11eb-9571-895b1647e245.png)
![image](https://user-images.githubusercontent.com/870716/121765424-a983ad00-cb85-11eb-8a55-5a593e04c32d.png)
![image](https://user-images.githubusercontent.com/870716/121765434-b7393280-cb85-11eb-8fbe-bd5c84dbfdc0.png)

作業時間 0.4h
