### PR TITLE
SPテンプレート管理ページ、ボタン幅を調整. #333

### DIFF
--- a/app/twig_templates/admin/blog_templates/index_sp.twig
+++ b/app/twig_templates/admin/blog_templates/index_sp.twig
@@ -17,7 +17,7 @@
     {% for device_type, blog_templates in device_blog_templates %}{# 機種毎のループ #}
 
         <div class="btn_area sp_no_template">
-            <ul class="btn_area_inner">
+            <ul class="btn_area_inner full_width">
                 <li>
                     <button class="btn_contents touch" onclick="location.href='{{ url(req, 'BlogTemplates', 'fc2_index', {device_type: device_type}) }}'"><i class="btn_icon"></i>{{ _('Template Search') }}</button>
                 </li>

--- a/public/assets/admin/css/sp/admin-fc2-sp.css
+++ b/public/assets/admin/css/sp/admin-fc2-sp.css
@@ -1624,6 +1624,10 @@ div.bg_white {
     width: 300px;
 }
 
+.btn_area_inner.full_width li {
+    width: 100%;
+}
+
 .btn_area_inner li:last-child {
     margin-right: 0;
 }


### PR DESCRIPTION
ref: #333 

- add `.btn_area_inner.fill_width` class.

![image](https://user-images.githubusercontent.com/870716/128587421-693454b8-0b93-41dd-b6c9-bec9806b55e5.png)

作業時間 0.2h