### PR TITLE
プラグイン検索における不要カラムの削除  #348

### DIFF
--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -116,6 +116,7 @@ class BlogPluginsController extends AdminController
         $this->set('devices', BlogTemplatesModel::DEVICE_NAME);
         $this->set('req_device_name', __(BlogTemplatesModel::getDeviceName((int)$request->get('device_type'))));
         $this->set('device_key', App::getDeviceFc2Key($request->get('device_type')));
+        $this->set('is_official', $is_official);
 
         return 'admin/blog_plugins/plugin_search.twig';
     }

--- a/app/twig_templates/admin/blog_plugins/plugin_search.twig
+++ b/app/twig_templates/admin/blog_plugins/plugin_search.twig
@@ -18,7 +18,9 @@
             <th>{{ _('Description') }}</th>
             <th>{{ _('Download') }}</th>
             <th>{{ _('Preview') }}</th>
-            <th>{{ _('Delete') }}</th>
+            {% if not is_official %}
+                <th>{{ _('Delete') }}</th>
+            {% endif %}
         </tr>
         </thead>
         <tbody>
@@ -32,11 +34,13 @@
                 <td class="center">
                     <a href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: req.get('category'), device_key: 1}, false, true, false) }}" target="_blank">{{ _('Preview') }}</a>
                 </td>
-                <td class="center">
-                    {% if user_id == plugin.user_id %}
-                        <a href="{{ url(req, 'blog_plugins', 'plugin_delete', {id: plugin.id, sig: sig}) }}" onclick="return confirm('{{ _('Are you sure you want to delete?') }}');">{{ _('Delete') }}</a>
-                    {% endif %}
-                </td>
+                {% if not is_official %}
+                    <td class="center">
+                        {% if user_id == plugin.user_id %}
+                            <a href="{{ url(req, 'blog_plugins', 'plugin_delete', {id: plugin.id, sig: sig}) }}" onclick="return confirm('{{ _('Are you sure you want to delete?') }}');">{{ _('Delete') }}</a>
+                        {% endif %}
+                    </td>
+                {% endif %}
             </tr>
         {% endfor %}
         </tbody>


### PR DESCRIPTION
ref: #348 

- 公式プラグイン検索において、削除カラムを削除。
- 共有プラグイン検索には残す

## 公式プラグイン

![image](https://user-images.githubusercontent.com/870716/128588709-98d06a59-7ee2-4c9b-ba5b-9ba0121253d5.png)

## 共有プラグイン

![image](https://user-images.githubusercontent.com/870716/128588712-db8d8baf-8db4-4bed-8c2c-a970319b8a85.png)
> 共有は削除カラムが必要


作業時間 0.4h