### PR TITLE
テンプレートで用いられている、req.get("id")などの廃止 #338

### DIFF
--- a/app/src/App.php
+++ b/app/src/App.php
@@ -241,11 +241,7 @@ class App
 
         // Cookieからデバイスタイプを取得
         $device_type = $request->rawCookie('device');
-        $devices = [
-            App::DEVICE_PC,
-            App::DEVICE_SP,
-        ];
-        if (!empty($device_type) && in_array($device_type, $devices)) {
+        if (!empty($device_type) && static::isExistsDeviceId($device_type)) {
             return (int)$device_type;
         }
 
@@ -262,6 +258,16 @@ class App
     }
 
     /**
+     * デバイスタイプが既知のものか？（許可されているか？）
+     * @param string $id
+     * @return bool
+     */
+    public static function isExistsDeviceId(string $id): bool
+    {
+        return in_array($id, self::ALLOW_DEVICES);
+    }
+
+    /**
      * デバイスタイプを取得する
      * @param Request $request
      * @return string|null
@@ -269,8 +275,7 @@ class App
     public static function getDeviceTypeStr(Request $request): string
     {
         $device_id = static::getDeviceType($request);
-        $device_table = App::DEVICE_FC2_KEY;
-        return $device_table[$device_id];
+        return App::DEVICE_FC2_KEY[$device_id] ?? App::DEVICE_FC2_KEY[App::DEVICE_PC];
     }
 
     /**

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -46,6 +46,7 @@ class BlogPluginsController extends AdminController
             }
         }
         $this->set('blog_plugin_json', $blog_plugin_json);
+        $this->set('state', $request->get('state'));
 
         return "admin/blog_plugins/index.twig";
     }

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -9,6 +9,7 @@ use Fc2blog\Model\BlogPluginsModel;
 use Fc2blog\Model\BlogTemplatesModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Model\PluginsModel;
+use Fc2blog\Util\Log;
 use Fc2blog\Web\Request;
 
 class BlogPluginsController extends AdminController
@@ -73,6 +74,8 @@ class BlogPluginsController extends AdminController
         return $this->plugin_search($request, false);
     }
 
+    const ALLOWED_PLUGIN_CATEGORY_TYPE_RANGE = "1-3";
+
     /**
      * プラグイン検索 （内部呼び出し）
      * @param Request $request
@@ -117,6 +120,11 @@ class BlogPluginsController extends AdminController
         $this->set('req_device_name', __(BlogTemplatesModel::getDeviceName((int)$request->get('device_type'))));
         $this->set('device_key', App::getDeviceFc2Key($request->get('device_type')));
         $this->set('is_official', $is_official);
+        if (!preg_match('/\A[' . self::ALLOWED_PLUGIN_CATEGORY_TYPE_RANGE . ']\z/u', $request->get('category'))) {
+            Log::notice("Request invalid plugin category type " . $request->get('category'));
+            return $this->error400();
+        }
+        $this->set('plugin_category_type_id', $request->get('category'));
 
         return 'admin/blog_plugins/plugin_search.twig';
     }

--- a/app/src/Web/Controller/Admin/BlogPluginsController.php
+++ b/app/src/Web/Controller/Admin/BlogPluginsController.php
@@ -191,13 +191,15 @@ class BlogPluginsController extends AdminController
         $this->set('device_type_sp', (string)App::DEVICE_SP);
 
         // 編集対象のデータ取得、なければリダイレクト
-        if (!$blog_plugin = $blog_plugins_model->findByIdAndBlogId($id, $blog_id)) {
+        $blog_plugin = $blog_plugins_model->findByIdAndBlogId($id, $blog_id);
+        if ($blog_plugin === false) {
             $this->redirect($request, array('action' => 'index'));
         }
 
         // 初期表示時に編集データの設定
         if (!$request->get('blog_plugin') || !$request->isValidSig()) {
             $request->set('blog_plugin', $blog_plugin);
+            $this->set('blog_plugin', $blog_plugin);
             return "admin/blog_plugins/edit.twig";
         }
 

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -177,13 +177,15 @@ class BlogTemplatesController extends AdminController
 
         $id = $request->get('id');
         $blog_id = $this->getBlogIdFromSession();
+        $blog_template = $blog_templates_model->findByIdAndBlogId($id, $blog_id);
 
         // 初期表示時に編集データの取得&設定
         if (!$request->get('blog_template') || !$request->isValidPost()) {
-            if (!$blog_template = $blog_templates_model->findByIdAndBlogId($id, $blog_id)) {
+            if (!$blog_template) {
                 $this->redirect($request, ['action' => 'index']);
             }
             $request->set('blog_template', $blog_template);
+            $this->set('blog_template', $blog_template);
             return "admin/blog_templates/edit.twig";
         }
 

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -10,6 +10,7 @@ use Fc2blog\Model\BlogTemplatesModel;
 use Fc2blog\Model\Fc2TemplatesModel;
 use Fc2blog\Model\Model;
 use Fc2blog\Service\BlogService;
+use Fc2blog\Util\Log;
 use Fc2blog\Web\Request;
 
 class BlogTemplatesController extends AdminController
@@ -45,6 +46,11 @@ class BlogTemplatesController extends AdminController
         }
         $this->set('device_blog_templates', $device_blog_templates);
         $this->set('devices', BlogTemplatesModel::DEVICE_NAME);
+        if (!App::isExistsDeviceId($request->get("device_type", (string)App::DEVICE_PC))) {
+            Log::notice("invalid device_type params :" . $request->get("device_type"));
+            return $this->error400();
+        }
+        $this->set('req_device_type', $request->get("device_type"));
 
         return "admin/blog_templates/index.twig";
     }
@@ -77,6 +83,11 @@ class BlogTemplatesController extends AdminController
         $this->set('templates', $templates);
         $this->set('paging', $paging);
         $this->set('devices', BlogTemplatesModel::DEVICE_NAME);
+        if (!App::isExistsDeviceId($request->get("device_type", (string)App::DEVICE_PC))) {
+            Log::notice("invalid device_type params :" . $request->get("device_type"));
+            return $this->error400();
+        }
+        $this->set('req_device_type', $request->get("device_type"));
 
         return "admin/blog_templates/fc2_index.twig";
     }
@@ -100,6 +111,12 @@ class BlogTemplatesController extends AdminController
         // デバイスタイプの設定
         $device_type = $request->get('device_type', (string)App::DEVICE_PC);
         $request->set('device_type', $device_type);
+
+        if (!App::isExistsDeviceId($request->get("device_type", (string)App::DEVICE_PC))) {
+            Log::notice("invalid device_type params :" . $request->get("device_type"));
+            return $this->error400();
+        }
+        $this->set('req_device_type', $request->get("device_type"));
 
         // テンプレート取得
         $device_key = App::getDeviceFc2Key($device_type);

--- a/app/src/Web/Controller/Admin/BlogTemplatesController.php
+++ b/app/src/Web/Controller/Admin/BlogTemplatesController.php
@@ -83,7 +83,7 @@ class BlogTemplatesController extends AdminController
         $this->set('templates', $templates);
         $this->set('paging', $paging);
         $this->set('devices', BlogTemplatesModel::DEVICE_NAME);
-        if (!App::isExistsDeviceId($request->get("device_type", (string)App::DEVICE_PC))) {
+        if (!App::isExistsDeviceId((string)$request->get("device_type", (string)App::DEVICE_PC))) {
             Log::notice("invalid device_type params :" . $request->get("device_type"));
             return $this->error400();
         }

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -79,12 +79,16 @@ class CategoriesController extends AdminController
         $options = $categories_model->getParentList($blog_id, $id);
         $this->set('category_parents', [0 => ''] + $options);
         $this->set('categories_model_order_list', $categories_model::getOrderList());
+        $category = $categories_model->findByIdAndBlogId($id, $blog_id);
+        $this->set('category', $category);
+
+        // 編集対象がみつからないので、新規作成にリダイレクト
+        if ($category === false) {
+            $this->redirect($request, ['action' => 'create']);
+        }
 
         // 初期表示時に編集データの取得&設定
         if (!$request->get('category') || !$request->isValidSig()) {
-            if (!$category = $categories_model->findByIdAndBlogId($id, $blog_id)) {
-                $this->redirect($request, ['action' => 'create']);
-            }
             $request->set('category', $category);
             return "admin/categories/edit.twig";
         }

--- a/app/src/Web/Controller/Admin/CategoriesController.php
+++ b/app/src/Web/Controller/Admin/CategoriesController.php
@@ -40,6 +40,7 @@ class CategoriesController extends AdminController
 
         // 初期表示時
         if (!$request->get('category') || !$request->isValidSig()) {
+            $this->set('show_category_list', true);
             return "admin/categories/create.twig";
         }
 

--- a/app/src/Web/Controller/Admin/TagsController.php
+++ b/app/src/Web/Controller/Admin/TagsController.php
@@ -83,10 +83,10 @@ class TagsController extends AdminController
     {
         $tags_model = new TagsModel();
 
-        $id = $request->get('id');
+        $tag_id = $request->get('id');
         $blog_id = $this->getBlogIdFromSession();
 
-        if (!$tag = $tags_model->findByIdAndBlogId($id, $blog_id)) {
+        if (!$tag = $tags_model->findByIdAndBlogId($tag_id, $blog_id)) {
             $this->redirect($request, ['action' => 'index']);
         }
         $this->set('tag', $tag);
@@ -104,11 +104,11 @@ class TagsController extends AdminController
         // 更新処理
         if (!$request->isPost()) return $this->error400();
         $tag_request = $request->get('tag');
-        $tag_request['id'] = $id;
+        $tag_request['id'] = $tag_id;
         $tag_request['blog_id'] = $blog_id;
         $errors['tag'] = $tags_model->validate($tag_request, $data, ['name']);
         if (empty($errors['tag'])) {
-            if ($tags_model->updateByIdAndBlogId($data, $id, $blog_id)) {
+            if ($tags_model->updateByIdAndBlogId($data, $tag_id, $blog_id)) {
                 $this->setInfoMessage(__('I have updated the tag'));
 
                 // 元の画面へ戻る

--- a/app/twig_templates/admin/blog_plugins/edit.twig
+++ b/app/twig_templates/admin/blog_plugins/edit.twig
@@ -6,7 +6,7 @@
 
     <form action="edit" method="post" id="sys-blog-plugin-form" class="admin-form">
 
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ blog_plugin.id }}"/>
         {{ input(req, 'blog_plugin[device_type]', 'hidden') }}
         {{ input(req, 'blog_plugin[category]', 'hidden') }}
         <input type="hidden" name="sig" value="{{ sig }}"/>

--- a/app/twig_templates/admin/blog_plugins/edit_sp.twig
+++ b/app/twig_templates/admin/blog_plugins/edit_sp.twig
@@ -6,7 +6,7 @@
 
     <form action="edit" method="post" id="sys-blog-plugin-form" class="admin-form">
 
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ blog_plugin.id }}"/>
         {{ input(req, 'blog_plugin[device_type]', 'hidden') }}
         {{ input(req, 'blog_plugin[category]', 'hidden') }}
         <input type="hidden" name="sig" value="{{ sig }}"/>

--- a/app/twig_templates/admin/blog_plugins/edit_sp.twig
+++ b/app/twig_templates/admin/blog_plugins/edit_sp.twig
@@ -71,7 +71,7 @@
     <div class="btn_area">
         <ul class="btn_area_inner">
             <li>
-                <a href="{{ url(req, 'blog_plugins', 'delete', {id: req.get('id'), sig: sig}) }}" class="btn_contents touch"
+                <a href="{{ url(req, 'blog_plugins', 'delete', {id: blog_plugin.id, sig: sig}) }}" class="btn_contents touch"
                    onclick="return confirm('{{ _('Are you sure you want to delete?') }}');"><i class="delete_icon btn_icon"></i>{{ _('Delete') }}</a>
             </li>
         </ul>

--- a/app/twig_templates/admin/blog_plugins/index_sp.twig
+++ b/app/twig_templates/admin/blog_plugins/index_sp.twig
@@ -288,15 +288,13 @@
             });
 
             // 初期表示
-            {% if req.get('state') == 'display' %}
+            {% if state == 'display' %}
             $('#plugin_radio_display').prop('checked', true);
             pluginSwitch('display');
-            {% endif %}
-            {% if req.get('state') == 'sort' %}
+            {% elseif state == 'sort' %}
             $('#plugin_radio_sort').prop('checked', true);
             pluginSwitch('sort');
-            {% endif %}
-            {% if req.get('state') != 'display' and req.get('state') == 'sort' %}
+            {% else %}
             pluginSwitch('detail');
             {% endif %}
         });

--- a/app/twig_templates/admin/blog_plugins/plugin_search.twig
+++ b/app/twig_templates/admin/blog_plugins/plugin_search.twig
@@ -29,10 +29,10 @@
                 <td>{{ t(plugin.title, 20) }}</td>
                 <td>{{ plugin.body|nl2br }}</td>
                 <td class="center">
-                    <a href="{{ url(req, 'blog_plugins', 'download', {id: plugin.id, category: req.get('category'), sig: sig}) }}">{{ _('Download') }}</a>
+                    <a href="{{ url(req, 'blog_plugins', 'download', {id: plugin.id, category: plugin_category_type_id, sig: sig}) }}">{{ _('Download') }}</a>
                 </td>
                 <td class="center">
-                    <a href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: req.get('category'), device_key: 1}, false, true, false) }}" target="_blank">{{ _('Preview') }}</a>
+                    <a href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: plugin_category_type_id, device_key: 1}, false, true, false) }}" target="_blank">{{ _('Preview') }}</a>
                 </td>
                 {% if not is_official %}
                     <td class="center">

--- a/app/twig_templates/admin/blog_plugins/plugin_search.twig
+++ b/app/twig_templates/admin/blog_plugins/plugin_search.twig
@@ -29,10 +29,21 @@
                 <td>{{ t(plugin.title, 20) }}</td>
                 <td>{{ plugin.body|nl2br }}</td>
                 <td class="center">
-                    <a href="{{ url(req, 'blog_plugins', 'download', {id: plugin.id, category: plugin_category_type_id, sig: sig}) }}">{{ _('Download') }}</a>
+                    <form action="{{ url(req, 'blog_plugins', 'download') }}" method="post">
+                        <input type="hidden" name="id" value="{{ plugin.id }}">
+                        <input type="hidden" name="category" value="{{ plugin_category_type_id }}">
+                        <input type="hidden" name="sig" value="{{ sig }}">
+                        <button>{{ _('Download') }}</button>
+                    </form>
                 </td>
                 <td class="center">
-                    <a href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: plugin_category_type_id, device_key: 1}, false, true, false) }}" target="_blank">{{ _('Preview') }}</a>
+                    <form action="{{ url(req, 'Entries', 'preview', {}, false, true, false) }}" method="post" target="_blank">
+                        <input type="hidden" name="blog_id" value="{{ blog.id }}">
+                        <input type="hidden" name="plugin_id" value="{{ plugin.id }}">
+                        <input type="hidden" name="category" value="{{ plugin_category_type_id }}">
+                        <input type="hidden" name="device_key" value="1">
+                        <button>{{ _('Preview') }}</button>
+                    </form>
                 </td>
                 {% if not is_official %}
                     <td class="center">

--- a/app/twig_templates/admin/blog_plugins/plugin_search_sp.twig
+++ b/app/twig_templates/admin/blog_plugins/plugin_search_sp.twig
@@ -13,8 +13,19 @@
                 <h4>{{ t(plugin.title, 20) }}</h4>
                 <p>{{ t(plugin.body, 20) }}</p>
                 <div class="parallel_btn">
-                    <a class="btn_contents touch" href="{{ url(req, 'blog_plugins', 'download', {id: plugin.id, category: plugin_category_type_id, sig: sig}) }}">{{ _('Add') }}</a>
-                    <a class="btn_contents touch" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: plugin_category_type_id, device_key: 1}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
+                    <form action="{{ url(req, 'blog_plugins', 'download') }}" method="post" style="display: inline">
+                        <input type="hidden" name="id" value="{{ plugin.id }}">
+                        <input type="hidden" name="category" value="{{ plugin_category_type_id }}">
+                        <input type="hidden" name="sig" value="{{ sig }}">
+                        <button class="btn_contents touch">{{ _('Add') }}</button>
+                    </form>
+                    <form action="{{ url(req, 'Entries', 'preview', {}, false, true, false) }}" method="post" target="_blank" style="display: inline">
+                        <input type="hidden" name="blog_id" value="{{ blog.id }}">
+                        <input type="hidden" name="plugin_id" value="{{ plugin.id }}">
+                        <input type="hidden" name="category" value="{{ plugin_category_type_id }}">
+                        <input type="hidden" name="device_key" value="1">
+                        <button class="btn_contents touch">{{ _('Preview') }}</button>
+                    </form>
                 </div>
             </li>
         {% endfor %}

--- a/app/twig_templates/admin/blog_plugins/plugin_search_sp.twig
+++ b/app/twig_templates/admin/blog_plugins/plugin_search_sp.twig
@@ -13,8 +13,8 @@
                 <h4>{{ t(plugin.title, 20) }}</h4>
                 <p>{{ t(plugin.body, 20) }}</p>
                 <div class="parallel_btn">
-                    <a class="btn_contents touch" href="{{ url(req, 'blog_plugins', 'download', {id: plugin.id, category: req.get('category'), sig: sig}) }}">{{ _('Add') }}</a>
-                    <a class="btn_contents touch" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: req.get('category'), device_key: 1}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
+                    <a class="btn_contents touch" href="{{ url(req, 'blog_plugins', 'download', {id: plugin.id, category: plugin_category_type_id, sig: sig}) }}">{{ _('Add') }}</a>
+                    <a class="btn_contents touch" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, plugin_id: plugin.id, category: plugin_category_type_id, device_key: 1}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
                 </div>
             </li>
         {% endfor %}

--- a/app/twig_templates/admin/blog_plugins/register.twig
+++ b/app/twig_templates/admin/blog_plugins/register.twig
@@ -9,7 +9,7 @@
 
     <form action="register" method="post" id="sys-plugin-form" class="admin-form">
 
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ blog_plugin.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
         <table>
             <tbody>

--- a/app/twig_templates/admin/blog_templates/edit.twig
+++ b/app/twig_templates/admin/blog_templates/edit.twig
@@ -7,7 +7,7 @@
 
     <form action="edit" method="post" id="sys-blog-template-form" class="admin-form">
 
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ blog_template.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
 
         <h3>{{ _('Template name') }}</h3>

--- a/app/twig_templates/admin/blog_templates/fc2_index.twig
+++ b/app/twig_templates/admin/blog_templates/fc2_index.twig
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <header><h2>{{ _('FC2 Template list') }}[{{ _(attribute(constant('Fc2blog\\App::DEVICE_FC2_KEY'), req.get('device_type'))) }}]</h2></header>
+    <header><h2>{{ _('FC2 Template list') }}[{{ _(attribute(constant('Fc2blog\\App::DEVICE_FC2_KEY'), req_device_type)) }}]</h2></header>
 
     {% if templates %}
         {% for template in templates %}
@@ -18,11 +18,11 @@
                 </tr>
                 <tr>
                     <td class="btn">
-                        <a class="admin_common_btn create_btn" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, fc2_id:template.id, device_type: req.get('device_type')}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
+                        <a class="admin_common_btn create_btn" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, fc2_id:template.id, device_type: req_device_type}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
                         <form action="{{ url(req, 'blog_templates', 'download') }}" method="post" style="display: inline">
                             <input type="hidden" name="sig" value="{{ sig }}">
                             <input type="hidden" name="fc2_id" value="{{ template.id }}">
-                            <input type="hidden" name="device_type" value="{{ req.get('device_type') }}">
+                            <input type="hidden" name="device_type" value="{{ req_device_type }}">
                             <button type="submit" class="admin_common_btn create_btn">{{ _('Download') }}</button>
                         </form>
 

--- a/app/twig_templates/admin/blog_templates/fc2_index_sp.twig
+++ b/app/twig_templates/admin/blog_templates/fc2_index_sp.twig
@@ -3,13 +3,13 @@
 
 {% block content %}
 
-    <header><h1 class="sh_heading_main_b">{{ _('FC2 Template list') }}[{{ _(attribute(constant('Fc2blog\\App::DEVICE_FC2_KEY'), req.get('device_type'))) }}]</h1></header>
+    <header><h1 class="sh_heading_main_b">{{ _('FC2 Template list') }}[{{ _(attribute(constant('Fc2blog\\App::DEVICE_FC2_KEY'), req_device_type)) }}]</h1></header>
 
     {% if templates %}
         <ul class="template_list">
             {% for template in templates %}
                 <li class="template_list_item">
-                    <a href="{{ url(req, 'blog_templates', 'fc2_view', {fc2_id: template.id, device_type: req.get('device_type')}) }}">
+                    <a href="{{ url(req, 'blog_templates', 'fc2_view', {fc2_id: template.id, device_type: req_device_type}) }}">
                         <img class="template_img" src="{{ template.image }}" alt="{{ template.name }}">
                         <p class="template_name">{{ template.name }}</p>
                     </a>

--- a/app/twig_templates/admin/blog_templates/fc2_view_sp.twig
+++ b/app/twig_templates/admin/blog_templates/fc2_view_sp.twig
@@ -3,14 +3,14 @@
 
 {% block content %}
 
-    <header><h1 class="sh_heading_main_b">{{ _('FC2 Template detail') }}[{{ _(attribute(constant('Fc2blog\\App::DEVICE_FC2_KEY'), req.get('device_type'))) }}]</h1></header>
+    <header><h1 class="sh_heading_main_b">{{ _('FC2 Template detail') }}[{{ _(attribute(constant('Fc2blog\\App::DEVICE_FC2_KEY'), req_device_type)) }}]</h1></header>
     <h2><span class="h2_inner">テンプレートの詳細</span></h2>
 
     <div class="template_detail">
         <form action="{{ url(req, 'blog_templates', 'download') }}" method="post" id="template_download_form">
             <input type="hidden" name="sig" value="{{ sig }}">
             <input type="hidden" name="fc2_id" value="{{ template.id }}">
-            <input type="hidden" name="device_type" value="{{ req.get('device_type') }}">
+            <input type="hidden" name="device_type" value="{{ req_device_type }}">
         </form>
         <div class="left_column">
             <p class="template_img">
@@ -19,7 +19,7 @@
         </div>
         <div class="right_column">
             <p>
-                <a class="btn_contents touch" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, fc2_id: template.id, device_type: req.get('device_type')}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
+                <a class="btn_contents touch" href="{{ url(req, 'Entries', 'preview', {blog_id: blog.id, fc2_id: template.id, device_type: req_device_type}, false, true) }}" target="_blank">{{ _('Preview') }}</a>
             </p>
             <p>
                 <button class="btn_contents touch" onclick="$('#template_download_form').submit()">{{ _('Download') }}</button>

--- a/app/twig_templates/admin/blog_templates/index_sp.twig
+++ b/app/twig_templates/admin/blog_templates/index_sp.twig
@@ -8,7 +8,7 @@
         <div class="form_contents">
             <select onchange="location.href=$(this).val();">
                 {% for key, device_en in devices %}
-                    <option value="{{ url(req, 'BlogTemplates', 'index', {device_type:key}) }}" {% if req.get('device_type') == key %}selected="selected"{% endif %}>{{ _(device_en) }}</option>
+                    <option value="{{ url(req, 'BlogTemplates', 'index', {device_type:key}) }}" {% if req_device_type == key %}selected="selected"{% endif %}>{{ _(device_en) }}</option>
                 {% endfor %}
             </select>
         </div>

--- a/app/twig_templates/admin/categories/create.twig
+++ b/app/twig_templates/admin/categories/create.twig
@@ -43,7 +43,7 @@
         </form>
     {% endif %}
 
-    {% if not req.get('category') %}
+    {% if show_category_list %}
         <h3>{{ _('Categories') }}</h3>
         <ul id="sys-category-list">
             {{ renderCategoriesTree2(req, categories) }}

--- a/app/twig_templates/admin/categories/create_sp.twig
+++ b/app/twig_templates/admin/categories/create_sp.twig
@@ -33,8 +33,7 @@
         {{ input(req, 'sig', 'hidden', {'value': sig}) }}
     </form>
 
-    {% if not req.get('category') %}
-
+    {% if show_category_list %}
         <h2><span class="h2_inner">{{ _('Categories') }}</span></h2>
         <div class="category_list">
             <ul id="sys-category-list">

--- a/app/twig_templates/admin/categories/edit.twig
+++ b/app/twig_templates/admin/categories/edit.twig
@@ -6,7 +6,7 @@
 
     <form action="edit" method="post" class="admin-form">
 
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ category.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
 
         <table>

--- a/app/twig_templates/admin/categories/edit_sp.twig
+++ b/app/twig_templates/admin/categories/edit_sp.twig
@@ -6,7 +6,7 @@
 
     <h2><span class="h2_inner">{{ _('Edit category') }}</span></h2>
     <form action="edit" method="post" class="admin-form">
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ category.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
         <div class="form_area">
             <div class="form_contents">

--- a/app/twig_templates/admin/categories/edit_sp.twig
+++ b/app/twig_templates/admin/categories/edit_sp.twig
@@ -39,7 +39,7 @@
             </li>
             {% if category.id != 1 %}
                 <li>
-                    <a href="{{ url(req, 'Categories', 'delete', {id: req.get('id'), sig: sig}) }}" class="btn_contents touch"
+                    <a href="{{ url(req, 'Categories', 'delete', {id: category.id, sig: sig}) }}" class="btn_contents touch"
                        onclick="return confirm('{{ _('If the child category exists\nRemove all along with the child category, but do you really want?') }}');"><i class="delete_icon btn_icon"></i>{{ _('Delete') }}</a>
                 </li>
             {% endif %}

--- a/app/twig_templates/admin/categories/edit_sp.twig
+++ b/app/twig_templates/admin/categories/edit_sp.twig
@@ -37,7 +37,7 @@
             <li>
                 <a class="btn_contents touch" href="{{ url(req, 'Categories', 'create') }}"><i class="return_icon btn_icon"></i>{{ _('I Back to List') }}</a>
             </li>
-            {% if req.get('id') != 1 %}
+            {% if category.id != 1 %}
                 <li>
                     <a href="{{ url(req, 'Categories', 'delete', {id: req.get('id'), sig: sig}) }}" class="btn_contents touch"
                        onclick="return confirm('{{ _('If the child category exists\nRemove all along with the child category, but do you really want?') }}');"><i class="delete_icon btn_icon"></i>{{ _('Delete') }}</a>

--- a/app/twig_templates/admin/files/edit.twig
+++ b/app/twig_templates/admin/files/edit.twig
@@ -7,10 +7,10 @@
     <form action="edit" method="post" id="sys-file-form" class="admin-form" enctype="multipart/form-data">
 
         <input type="hidden" name="MAX_FILE_SIZE" value="{{ file_max_size }}"/>
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ file.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
 
-        <a href="{{ file['path'] }}" target="_blank"><img src="{{ file['thumbnail_path'] }}" alt="{{ file.name }}"/></a>
+        <a href="{{ file['path'] }}" target="_blank"><img src="{{ file.thumbnail_path }}" alt="{{ file.name }}"/></a>
 
         {% if errors.file.ext %}
             <p class="error">{{ errors.file.ext }}</p>

--- a/app/twig_templates/admin/files/edit_sp.twig
+++ b/app/twig_templates/admin/files/edit_sp.twig
@@ -17,7 +17,7 @@
     <h2><span class="h2_inner">{{ _('Edit File') }}</span></h2>
     <form action="edit" method="post" id="sys-file-form" class="admin-form" enctype="multipart/form-data">
         <input type="hidden" name="MAX_FILE_SIZE" value="{{ max_file_size }}"/>
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ file.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
         <div class="btn_area">
             <div class="up_file_btn">

--- a/app/twig_templates/admin/tags/edit.twig
+++ b/app/twig_templates/admin/tags/edit.twig
@@ -6,7 +6,7 @@
 
     <form action="edit" method="post" id="sys-tag-form" class="admin-form">
 
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ tag.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
 
         <table>

--- a/app/twig_templates/admin/tags/edit_sp.twig
+++ b/app/twig_templates/admin/tags/edit_sp.twig
@@ -6,7 +6,7 @@
 
     <h2><span class="h2_inner">{{ _('Edit tag') }}</span></h2>
     <form action="edit" method="post" id="sys-tag-form" class="admin-form">
-        <input type="hidden" name="id" value="{{ req.get('id') }}"/>
+        <input type="hidden" name="id" value="{{ tag.id }}"/>
         <input type="hidden" name="sig" value="{{ sig }}"/>
         {{ input(req, 'back_url', 'hidden', {'default': req.get('back_url')}) }}
         <div class="form_area">


### PR DESCRIPTION
ref #338 

- templateにおける`req.get("id")`を全て消した
- pluginにおける `req.get("category")`を消した
- device_type、stateも
- 一部にバリデーションを追加
- プラグイン追加が正しく動作していなかったバグを修正

> back_url, keywordはもうすこし手間が掛かりそうなので、別ISSUEにします。

作業時間 2.5h