### PR TITLE
Avoid bind mount for mysql data dir. speed up tests x1.6 times.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ test: app/vendor e2e_test/node_modules tests/test_images/0.png
 	$(dexec) php composer.phar run test
 	$(dexec) bash -c "cd e2e_test && BASE_URL=http://localhost npm run test"
 
+.PHONY: phpunit
+phpunit: app/vendor
+	make reload-test-data
+	$(dexec) php composer.phar run test
+
 .PHONY: e2etest
 e2etest: app/vendor e2e_test/node_modules tests/test_images/0.png
 	make reload-test-data
@@ -47,6 +52,7 @@ docker-compose-build-no-cache:
 	$(eval UID := $(shell id -u))
 	$(eval GID := $(shell id -g))
 	@docker-compose build --no-cache --build-arg PUID=$(UID) --build-arg PGID=$(GID) php
+	@docker-compose build --no-cache --build-arg PUID=$(UID) --build-arg PGID=$(GID) db
 
 .PHONY:
 docker-compose-build:
@@ -54,6 +60,7 @@ docker-compose-build:
 	$(eval UID := $(shell id -u))
 	$(eval GID := $(shell id -g))
 	@docker-compose build --build-arg PUID=$(UID) --build-arg PGID=$(GID) php
+	@docker-compose build --build-arg PUID=$(UID) --build-arg PGID=$(GID) db
 
 .PHONY: mysql-shell
 mysql-shell:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       MYSQL_USER: docker
       MYSQL_PASSWORD: docker
     volumes:
-      - ./docker/mysqld/data:/var/lib/mysql
+      - fc2blog-mysql-data:/var/lib/mysql
     ports:
       - 3306:3306
 
@@ -56,3 +56,6 @@ services:
     ports:
       - 8080:80
       - 8480:443
+
+volumes:
+  fc2blog-mysql-data:

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,1 +1,0 @@
-mysqld/data/*


### PR DESCRIPTION
- improve development env.
- phpunit running time sample in my local env.
- before: Time: 01:50.146, Memory: 38.00 MB
- after: Time: 01:08.482, Memory: 38.00 MB

(0.5h